### PR TITLE
Support for RDM in container

### DIFF
--- a/BryanChi_FX_Devices/BryanChi_FX Devices.lua
+++ b/BryanChi_FX_Devices/BryanChi_FX Devices.lua
@@ -7,35 +7,8 @@
 --  - Fixed PLink bug when RDM is inserted
 --  - Made the vertical tab scrollable by left dragging it
 -- @provides
---   [effect] FXD JSFXs/FXD (Mix)RackMixer.jsfx
---   [effect] FXD JSFXs/FXD Band Joiner.jsfx
---   [effect] FXD JSFXs/FXD Gain Reduction Scope.jsfx
---   [effect] FXD JSFXs/FXD Macros.jsfx
---   [effect] FXD JSFXs/FXD ReSpectrum.jsfx
---   [effect] FXD JSFXs/FXD Saike BandSplitter.jsfx
---   [effect] FXD JSFXs/FXD Split to 32 Channels.jsfx
---   [effect] FXD JSFXs/FXD Split To 4 Channels.jsfx
---   [effect] FXD JSFXs/cookdsp.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/analysis.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/buffer.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/delay.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/dynamics.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/effects.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/fftobjects.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/filters.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/granulator.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/list.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/memalloc.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/midi.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/mmath.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/oscil.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/pobjects.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/pvocobjects.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/random.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/scaling.jsfx-inc
---   [effect] FXD JSFXs/firhalfband.jsfx-inc
---   [effect] FXD JSFXs/spectrum.jsfx-inc
---   [effect] FXD JSFXs/svf_filter.jsfx-inc
+--   [effect] FXD JSFXs/*.jsfx
+--   [effect] FXD JSFXs/*.jsfx-inc
 --   src/FX Layouts/ValhallaDelay (Valhalla DSP, LLC).ini
 --   src/FX Layouts/ValhallaFreqEcho (Valhalla DSP, LLC).ini
 --   src/FX Layouts/ValhallaShimmer (Valhalla DSP, LLC).ini
@@ -59,32 +32,17 @@
 --   src/Images/Knobs/FancyBlueKnob.png
 --   src/Images/Knobs/FancyLightGreenKnob.png
 --   src/Images/Switches/FancyGreenCheck_2.png
---   src/LFO Shapes/Square.ini
---   src/LFO Shapes/Sine.ini
---   src/LFO Shapes/Saw L.ini
---   src/LFO Shapes/Saw R.ini
---   src/LFO Shapes/Triangle.ini
---   src/FX Layout Plugin Scripts/Container.lua
---   src/FX Layout Plugin Scripts/Pro Q 3.lua
---   src/FX Layout Plugin Scripts/Pro C 2.lua
---   src/FX Layout Plugin Scripts/ReaComp.lua
---   src/FX Layout Plugin Scripts/ReaDrum Machine.lua
---   src/FX Layout Plugin Scripts/Volume Pan Smoother.lua
+--   src/LFO Shapes/*.ini
+--   src/FX Layout Plugin Scripts/*.lua
 --   src/IconFont1.ttf
 --   [main] src/FXD - Record Last Touch.lua
---   src/Functions/EQ functions.lua
---   src/Functions/General Functions.lua
---   src/Functions/FX Layering.lua
---   src/Functions/Layout Editor functions.lua
---   src/Functions/Modulation.lua
---   src/Functions/Theme Editor Functions.lua
---   src/Functions/Filesystem_utils.lua
+--   src/Functions/*.lua
 --   src/Constants.lua
 --   src/FXChains/ReaDrum Machine.RfxChain
-
 -- @about
 --   Please check the forum post for info:
---   https://forum.cockos.com/showthread.php?t=263622-- dofile("/home/antoine/Documents/Experiments/lua/debug_connect.lua")
+--   https://forum.cockos.com/showthread.php?t=263622
+-- dofile("/home/antoine/Documents/Experiments/lua/debug_connect.lua")
 
 ---@type string
 CurrentDirectory = debug.getinfo(1, "S").source:match [[^@?(.*[\/])[^\/]-$]] -- GET DIRECTORY FOR REQUIRE

--- a/BryanChi_FX_Devices/src/FX Layout Plugin Scripts/ReaDrum Machine.lua
+++ b/BryanChi_FX_Devices/src/FX Layout Plugin Scripts/ReaDrum Machine.lua
@@ -11,8 +11,6 @@
 
 r = reaper
 Pad          = {}
-local customcolors = require("src.helpers.custom_colors")
-local CustomColorsDefault = customcolors.CustomColorsDefault
 
 local FX_Idx = PluginScript.FX_Idx
 local FxGUID = PluginScript.Guid
@@ -55,15 +53,16 @@ local function DndMoveFXtoPad_TARGET_SWAP(a)
     r.ImGui_EndDragDropTarget(ctx)
     r.Undo_BeginBlock()
     r.PreventUIRefresh(1)
-    GetDrumMachineIdx()
+    GetDrumMachineIdx(track)
     if FX_Drag and Mods == 0 then
         if Pad[a] then   -- add fx to target
           local dst_pad = Pad[a].Pad_ID
           local dst_num = Pad[a].Pad_Num
           -- dst_guid = Pad[a].Pad_GUID
           local dstfx_idx = CountPadFX(dst_num)
-          dstfx_idx = dstfx_idx + 1 -- the last slot being offset by 1
-          local dst_last = get_fx_id_from_container_path(track, parent_id, dst_num, dstfx_idx)
+          local dstfx_idx = dstfx_idx + 1 -- the last slot being offset by 1
+          local dst_id = ConvertPathToNestedPath(parent_id, dst_num)
+          local dst_last = ConvertPathToNestedPath(dst_id, dstfx_idx)
           r.TrackFX_CopyToTrack(LT_Track, DragFX_ID, LT_Track, dst_last, true) -- true = move
           r.PreventUIRefresh(-1)
           EndUndoBlock("ADD FX TO PAD")
@@ -71,8 +70,8 @@ local function DndMoveFXtoPad_TARGET_SWAP(a)
           CountPads()
           AddPad(note_name, a) -- dst
           AddNoteFilter(notenum, pad_num)
-          local previous_pad_id = get_fx_id_from_container_path(track, parent_id, pad_num - 1)
-          local next_pad_id = get_fx_id_from_container_path(track, parent_id, pad_num + 1)
+          local previous_pad_id = ConvertPathToNestedPath(parent_id, pad_num - 1)
+          local next_pad_id = ConvertPathToNestedPath(parent_id, pad_num + 1)
           Pad[a] = { -- dst
             Previous_Pad_ID = previous_pad_id,
             Pad_ID = pad_id,
@@ -82,8 +81,9 @@ local function DndMoveFXtoPad_TARGET_SWAP(a)
             Note_Num = notenum
           }
           local dstfx_idx = CountPadFX(pad_num) 
-          dstfx_idx = dstfx_idx + 1 -- the last slot being offset by 1
-          local dst_last = get_fx_id_from_container_path(track, parent_id, pad_num, dstfx_idx)
+          local dstfx_idx = dstfx_idx + 1 -- the last slot being offset by 1
+          local pad_id = ConvertPathToNestedPath(parent_id, pad_num)
+          local dst_last = ConvertPathToNestedPath(pad_id, dstfx_idx)
           r.TrackFX_CopyToTrack(LT_Track, DragFX_ID, LT_Track, dst_last, true) -- true = move
           r.PreventUIRefresh(-1)
           EndUndoBlock("MOVE FX TO PAD")
@@ -165,8 +165,9 @@ local function OpenFXInsidePad(a)
   if not Pad[a] then return end 
   CountPadFX(Pad[a].Pad_Num) -- padfx_idx
   for f = 1, padfx_idx do
-    FX_Id = get_fx_id_from_container_path(track, parent_id, Pad[a].Pad_Num, f)
-    FX_Id_next = get_fx_id_from_container_path(track, parent_id, Pad[a].Pad_Num, f + 1)
+    local _, pad_id = r.TrackFX_GetNamedConfigParm(track, parent_id, "container_item." .. Pad[a].Pad_Num - 1) -- 0 based
+    local FX_Id = ConvertPathToNestedPath(pad_id, f)
+    local FX_Id_next = ConvertPathToNestedPath(pad_id, f + 1)
     local GUID = r.TrackFX_GetFXGUID(LT_Track, FX_Id)
     Spc = AddSpaceBtwnFXs(FX_Id)
     r.ImGui_SameLine(ctx, nil, 0)
@@ -242,12 +243,12 @@ local function DrawPads(loopmin, loopmax)
         local retval2 = r.TrackFX_GetEnabled(track, Pad[a].Next_Pad_ID)
         if retval1 == false and retval2 == false then -- unsolo
           for i = 1, pads_idx do
-            local pad_id = get_fx_id_from_container_path(track, parent_id, i)
+            local _, pad_id = r.TrackFX_GetNamedConfigParm(track, parent_id, "container_item." .. i - 1) -- 0 based
             r.TrackFX_SetEnabled(track, pad_id, true)
           end
         else -- solo
           for i = 1, pads_idx do
-            local pad_id = get_fx_id_from_container_path(track, parent_id, i)
+            local _, pad_id = r.TrackFX_GetNamedConfigParm(track, parent_id, "container_item." .. i - 1) -- 0 based
             r.TrackFX_SetEnabled(track, pad_id, false)
           end
           r.TrackFX_SetEnabled(track, Pad[a].Pad_ID, true)


### PR DESCRIPTION
Hi, sorry for bothering you again!

+ Updated RDM layout script as I added support for RDM in container in my script

I changed @provides as follows so that you don't forget to add a line when you will add a new jsfx, FX Layout Plugin Scripts, and LFO shapes. I didn't do this for FX Layouts and Images because some of files look to be not there to provide for users. I also do this in my script, but if you prefer the previous way, feel free to discard this change!
```
--   [effect] FXD JSFXs/*.jsfx
--   [effect] FXD JSFXs/*.jsfx-inc
```

Unrelated to the update, btw, FX Layout Plugin Scripts in container retunrs an error .
```
...nChi_FX_Devices\src/FX Layout Plugin Scripts/Pro C 2.lua:20: attempt to index a nil value (field '?')
```