### PR TITLE
Added general setttings menu and improved scroll behavior

### DIFF
--- a/BryanChi_FX_Devices/BryanChi_FX Devices.lua
+++ b/BryanChi_FX_Devices/BryanChi_FX Devices.lua
@@ -3,176 +3,154 @@
 -- @version 1.0beta12
 -- @changelog
 --  - Add option to use native gain reduction values for Pro-C
---  - Add option to disable using Respectrum on Pro-Q 
+--  - Add option to disable using Respectrum on Pro-Q
 
 -- @provides
---   [effect] FXD JSFXs/FXD (Mix)RackMixer.jsfx
---   [effect] FXD JSFXs/FXD Band Joiner.jsfx
---   [effect] FXD JSFXs/FXD Gain Reduction Scope.jsfx
---   [effect] FXD JSFXs/FXD Macros.jsfx
---   [effect] FXD JSFXs/FXD ReSpectrum.jsfx
---   [effect] FXD JSFXs/FXD Saike BandSplitter.jsfx
---   [effect] FXD JSFXs/FXD Split to 32 Channels.jsfx
---   [effect] FXD JSFXs/FXD Split To 4 Channels.jsfx
---   [effect] FXD JSFXs/cookdsp.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/analysis.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/buffer.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/delay.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/dynamics.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/effects.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/fftobjects.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/filters.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/granulator.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/list.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/memalloc.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/midi.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/mmath.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/oscil.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/pobjects.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/pvocobjects.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/random.jsfx-inc
---   [effect] FXD JSFXs/cookdsp/scaling.jsfx-inc
---   [effect] FXD JSFXs/firhalfband.jsfx-inc
---   [effect] FXD JSFXs/spectrum.jsfx-inc
---   [effect] FXD JSFXs/svf_filter.jsfx-inc
+--   [effect] FXD JSFXs/*.jsfx
+--   [effect] FXD JSFXs/*.jsfx-inc
+--   src/FX Layouts/ReaComp (Cockos).ini
 --   src/FX Layouts/ValhallaDelay (Valhalla DSP, LLC).ini
 --   src/FX Layouts/ValhallaFreqEcho (Valhalla DSP, LLC).ini
 --   src/FX Layouts/ValhallaShimmer (Valhalla DSP, LLC).ini
 --   src/FX Layouts/ValhallaSpaceModulator (Valhalla DSP, LLC).ini
 --   src/FX Layouts/ValhallaSupermassive (Valhalla DSP, LLC).ini
 --   src/FX Layouts/ValhallaVintageVerb (Valhalla DSP, LLC).ini
---   src/FX Layouts/ReaComp (Cockos).ini
---   src/Images/Attached Drawings/LED light.png 
---   src/Images/Knobs/Bitwig.png
---   src/Images/Knobs/FancyRedKnob.png
 --   src/Images/Analog Knob 1.png
---   src/Images/trash.png
+--   src/Images/copy.png
 --   src/Images/sinewave.png
 --   src/Images/save.png
+--   src/Images/trash.png
 --   src/Images/pinned.png
 --   src/Images/pin.png
 --   src/Images/paste.png
---   src/Images/copy.png
---   src/Images/Knobs/FancyGreenKnob.png
+--   src/Images/Attached Drawings/LED light.png
+--   src/Images/Knobs/Bitwig.png
 --   src/Images/Knobs/FancyBlueKnob_Inverted.png
 --   src/Images/Knobs/FancyBlueKnob.png
+--   src/Images/Knobs/FancyGreenKnob.png
 --   src/Images/Knobs/FancyLightGreenKnob.png
+--   src/Images/Knobs/FancyRedKnob.png
 --   src/Images/Switches/FancyGreenCheck_2.png
---   src/LFO Shapes/Square.ini
---   src/LFO Shapes/Sine.ini
---   src/LFO Shapes/Saw L.ini
---   src/LFO Shapes/Saw R.ini
---   src/LFO Shapes/Triangle.ini
---   src/FX Layout Plugin Scripts/Container.lua 
---   src/FX Layout Plugin Scripts/Pro Q 3.lua
---   src/FX Layout Plugin Scripts/Pro C 2.lua
---   src/FX Layout Plugin Scripts/ReaComp.lua
---   src/FX Layout Plugin Scripts/ReaDrum Machine.lua  
---   src/FX Layout Plugin Scripts/Volume Pan Smoother.lua
+--   src/LFO Shapes/*.ini
+--   src/FX Layout Plugin Scripts/*.lua
 --   src/IconFont1.ttf
 --   [main] src/FXD - Record Last Touch.lua
---   src/Functions/EQ functions.lua
---   src/Functions/General Functions.lua
---   src/Functions/FX Layering.lua
---   src/Functions/Layout Editor functions.lua
---   src/Functions/Modulation.lua
---   src/Functions/Theme Editor Functions.lua
---   src/Functions/Filesystem_utils.lua
+--   src/Functions/*.lua
 --   src/Constants.lua
 --   src/FXChains/ReaDrum Machine.RfxChain
 
 -- @about
 --   Please check the forum post for info:
---   https://forum.cockos.com/showthread.php?t=263622-- dofile("/home/antoine/Documents/Experiments/lua/debug_connect.lua")
+--   https://forum.cockos.com/showthread.php?t=263622
+-- dofile("/home/antoine/Documents/Experiments/lua/debug_connect.lua")
 
 ---@type string
 CurrentDirectory = debug.getinfo(1, "S").source:match [[^@?(.*[\/])[^\/]-$]] -- GET DIRECTORY FOR REQUIRE
 package.path = CurrentDirectory .. "?.lua;"
 
+r = reaper
+
+local reaimgui_force_version = "0.8.7.6"
+
+if reaimgui_force_version then
+    local reaimgui_shim_file_path = r.GetResourcePath() .. '/Scripts/ReaTeam Extensions/API/imgui.lua'
+    if r.file_exists(reaimgui_shim_file_path) then
+        dofile(reaimgui_shim_file_path)(reaimgui_force_version)
+    end
+end
 
 function ThirdPartyDeps()
-    local ultraschall_path = reaper.GetResourcePath() .. "/UserPlugins/ultraschall_api.lua"
-    local readrum_machine = reaper.GetResourcePath() .. "/Scripts/Suzuki Scripts/ReaDrum Machine/Suzuki_ReaDrum_Machine_Instruments_Rack.lua"
+    local ultraschall_path = r.GetResourcePath() .. "/UserPlugins/ultraschall_api.lua"
+    local readrum_machine = r.GetResourcePath() ..
+        "/Scripts/Suzuki Scripts/ReaDrum Machine/Suzuki_ReaDrum_Machine_Instruments_Rack.lua"
 
-    local version = tonumber (string.sub( reaper.GetAppVersion() ,  0, 4))
+    local version = tonumber(string.sub(r.GetAppVersion(), 0, 4))
     --reaper.ShowConsoleMsg((version))
 
     local fx_browser_path
-    local n,arch = reaper.GetAppVersion():match("(.+)/(.+)")
+    local n, arch = r.GetAppVersion():match("(.+)/(.+)")
     local fx_browser_v6_path
-    
-    if n:match("^7%.") then
-        fx_browser = reaper.GetResourcePath() .. "/Scripts/Sexan_Scripts/FX/Sexan_FX_Browser_ParserV7.lua"
-        fx_browser_reapack = 'sexan fx browser parser v7' 
-    else
-        fx_browser= reaper.GetResourcePath() .. "/Scripts/Sexan_Scripts/FX/Sexan_FX_Browser_Parser.lua"  
-        fx_browser_v6_path = reaper.GetResourcePath() .. "/Scripts/Sexan_Scripts/FX/Sexan_FX_Browser_Parser.lua"
-       fx_browser_reapack = 'sexan fx browser parser v6'
 
+    if n:match("^7%.") then
+        fx_browser = r.GetResourcePath() .. "/Scripts/Sexan_Scripts/FX/Sexan_FX_Browser_ParserV7.lua"
+        fx_browser_reapack = 'sexan fx browser parser v7'
+    else
+        fx_browser = r.GetResourcePath() .. "/Scripts/Sexan_Scripts/FX/Sexan_FX_Browser_Parser.lua"
+        fx_browser_v6_path = r.GetResourcePath() .. "/Scripts/Sexan_Scripts/FX/Sexan_FX_Browser_Parser.lua"
+        fx_browser_reapack = 'sexan fx browser parser v6'
     end
     --local fx_browser_v6_path = reaper.GetResourcePath() .. "/Scripts/Sexan_Scripts/FX/Sexan_FX_Browser_Parser.lua"
     --local fx_browser_v7_path = reaper.GetResourcePath() .. "/Scripts/Sexan_Scripts/FX/Sexan_FX_Browser_ParserV7.lua"
-    
+
     local reapack_process
     local repos = {
-      {name = "Sexan_Scripts", url = 'https://github.com/GoranKovac/ReaScripts/raw/master/index.xml'},
-      {name = "Ultraschall-API", url = 'https://github.com/Ultraschall/ultraschall-lua-api-for-reaper/raw/master/ultraschall_api_index.xml'},
-      {name = "Suzuki Scripts", url = 'https://github.com/Suzuki-Re/Suzuki-Scripts/raw/master/index.xml'},
+        { name = "Sexan_Scripts",   url = 'https://github.com/GoranKovac/ReaScripts/raw/master/index.xml' },
+        { name = "Suzuki Scripts",  url = 'https://github.com/Suzuki-Re/Suzuki-Scripts/raw/master/index.xml' },
+        { name = "Ultraschall-API", url = 'https://github.com/Ultraschall/ultraschall-lua-api-for-reaper/raw/master/ultraschall_api_index.xml' },
     }
-    
+
     for i = 1, #repos do
-      local retinfo, url, enabled, autoInstall = reaper.ReaPack_GetRepositoryInfo( repos[i].name )
-      if not retinfo then
-        retval, error = reaper.ReaPack_AddSetRepository( repos[i].name, repos[i].url, true, 0 )
-        reapack_process = true
-      end
+        local retinfo, url, enabled, autoInstall = r.ReaPack_GetRepositoryInfo(repos[i].name)
+        if not retinfo then
+            retval, error = r.ReaPack_AddSetRepository(repos[i].name, repos[i].url, true, 0)
+            reapack_process = true
+        end
     end
-   
+
     -- ADD NEEDED REPOSITORIES
     if reapack_process then
-      reaper.ShowMessageBox("Added Third-Party ReaPack Repositories", "ADDING REPACK REPOSITORIES", 0)
-      reaper.ReaPack_ProcessQueue(true)
-      reapack_process = nil
+        r.ShowMessageBox("Added Third-Party ReaPack Repositories", "ADDING REPACK REPOSITORIES", 0)
+        r.ReaPack_ProcessQueue(true)
+        reapack_process = nil
     end
-    
+
     if not reapack_process then
-      -- ULTRASCHALL
-      if reaper.file_exists(ultraschall_path) then
-          dofile(ultraschall_path)
-      else
-          reaper.ShowMessageBox("Ultraschall API is needed.\nPlease Install it in next window", "MISSING DEPENDENCIES", 0)
-          reaper.ReaPack_BrowsePackages('ultraschall')
-          return 'error ultraschall'
-      end
-      -- FX BROWSER
-      if reaper.file_exists(fx_browser) then
-          dofile(fx_browser)
-      else
-         reaper.ShowMessageBox("Sexan FX BROWSER is needed.\nPlease Install it in next window", "MISSING DEPENDENCIES", 0)
-         reaper.ReaPack_BrowsePackages(fx_browser_reapack)
-         return 'error Sexan FX BROWSER'
-      end
-      -- ReaDrum Machine
-      if reaper.file_exists(readrum_machine) then
-        local found_readrum_machine = true
-      else
-      reaper.ShowMessageBox("ReaDrum Machine is needed.\nPlease Install it in next window", "MISSING DEPENDENCIES", 0)
-      reaper.ReaPack_BrowsePackages('readrum machine')
-      return 'error Suzuki ReaDrum Machine'
-      end
+        -- FX BROWSER
+        if r.file_exists(fx_browser) then
+            dofile(fx_browser)
+        else
+            r.ShowMessageBox("Sexan FX BROWSER is needed.\nPlease Install it in next window", "MISSING DEPENDENCIES",
+                0)
+            r.ReaPack_BrowsePackages(fx_browser_reapack)
+            return 'error Sexan FX BROWSER'
+        end
+        -- js extension
+        if r.APIExists("JS_ReaScriptAPI_Version") then
+            local js_extension = true
+        else
+            r.ShowMessageBox("js Extension is needed.\nPlease Install it in next window", "MISSING DEPENDENCIES", 0)
+            r.ReaPack_BrowsePackages('js_ReascriptAPI')
+            return 'error js Extension'
+        end
+        -- ReaDrum Machine
+        if r.file_exists(readrum_machine) then
+            local found_readrum_machine = true
+        else
+            r.ShowMessageBox("ReaDrum Machine is needed.\nPlease Install it in next window", "MISSING DEPENDENCIES",
+                0)
+            r.ReaPack_BrowsePackages('readrum machine')
+            return 'error Suzuki ReaDrum Machine'
+        end
+        -- ULTRASCHALL
+        if r.file_exists(ultraschall_path) then
+            dofile(ultraschall_path)
+        else
+            r.ShowMessageBox("Ultraschall API is needed.\nPlease Install it in next window", "MISSING DEPENDENCIES",
+                0)
+            r.ReaPack_BrowsePackages('ultraschall')
+            return 'error ultraschall'
+        end
     end
 end
 
 if ThirdPartyDeps() then return end
 
 function msg(...)
-    for i , v in ipairs({...}) do 
+    for i, v in ipairs({ ... }) do
         r.ShowConsoleMsg(tostring(v) .. "\n")
     end
 end
 
-
-r = reaper
 require("src.Functions.General Functions")
 require("src.Functions.EQ functions")
 require("src.Functions.Layout Editor functions")
@@ -190,9 +168,9 @@ os_separator = package.config:sub(1, 1)
 VersionNumber = '1.0beta10.12'
 FX_Add_Del_WaitTime = 2
 
- FX_LIST, CAT = ReadFXFile()
+FX_LIST, CAT = ReadFXFile()
 if not FX_LIST or not CAT then
-   FX_LIST, CAT = MakeFXFiles()
+    FX_LIST, CAT = MakeFXFiles()
 end
 
 ---@class ViewPort
@@ -217,9 +195,9 @@ Draw = {
 AddFX = { Pos = {}, Name = {}, GUID = {} }
 DelFX = { Pos = {}, Name = {} }
 MovFX = { ToPos = {}, FromPos = {}, Lbl = {}, Copy = {} }
-LO = {} ; -- layout for plugins
+LO = {}; -- layout for plugins
 
-LFO = { Win = { w = 400, h = 300} ; CtrlNodeSz=6; NodeSz = 6; Def={Len = 4 } }
+LFO = { Win = { w = 400, h = 300 }, CtrlNodeSz = 6, NodeSz = 6, Def = { Len = 4 } }
 
 LFOwin = { w = 400, h = 300 }
 ClrPallet = {}
@@ -235,14 +213,13 @@ StepSEQ_H = 100
 SEQ_Default_Num_of_Steps = 8
 SEQ_Default_Denom = 1
 
-
-
-
 ----------- Custom Colors-------------------
 CustomColors = { 'Window_BG', 'FX_Devices_Bg', 'FX_Layer_Container_BG', 'Space_Between_FXs', 'Morph_A', 'Morph_B',
-    'Layer_Solo', 'Layer_Mute', 'FX_Adder_VST', 'FX_Adder_VST3', 'FX_Adder_JS', 'FX_Adder_AU', 'FX_Adder_CLAP', 'FX_Adder_LV2', 
-    'PLink', 'PLink_Edge_DarkBG', 'PLink_Edge_LightBG', 
-    'RDM_BG', 'RDM_VTab', 'RDM_VTab_Highlight', 'RDM_VTab_Highlight_Edge', 'RDM_PadOff', 'RDM_PadOn', 'RDM_Pad_Highlight', 'RDM_Play', 'RDM_Solo', 'RDM_Mute', 'RDM_DnDFX', 'RDM_DnD_Move'}
+    'Layer_Solo', 'Layer_Mute', 'FX_Adder_VST', 'FX_Adder_VST3', 'FX_Adder_JS', 'FX_Adder_AU', 'FX_Adder_CLAP',
+    'FX_Adder_LV2',
+    'PLink', 'PLink_Edge_DarkBG', 'PLink_Edge_LightBG',
+    'RDM_BG', 'RDM_VTab', 'RDM_VTab_Highlight', 'RDM_VTab_Highlight_Edge', 'RDM_PadOff', 'RDM_PadOn', 'RDM_Pad_Highlight',
+    'RDM_Play', 'RDM_Solo', 'RDM_Mute', 'RDM_DnDFX', 'RDM_DnD_Move' }
 CustomColorsDefault = {
     Window_BG = 0x000000ff,
     FX_Devices_Bg = 0x151515ff,
@@ -421,18 +398,12 @@ Command_ID = {}
 --------Pro C ------------------------
 ProC = { Width = 280, Pt = { R = { m = {}, M = {} }, L = { m = {}, M = {} } } }
 
-ProC.GR_NATIVE = StringToBool[ r.GetExtState('FXD', 'Use Native Gain Reduction for Pro-C' )]
-
-
 
 ------- Pro Q -------------------------
-ProQ={}
-ProQ.Analyzer = StringToBool[ r.GetExtState('FXD', 'Use analyzer for Pro-Q' )]
+ProQ = {}
 
 
-
-
--------------------Macros --------------------------
+------------------- Macros --------------------------
 Mc = { Val_Trk = {}, V_Out = { 0, 0, 0, 0, 0, 0, 0, 0, 0 }, Name = {} }
 Wet = { DragLbl = {}, Val = {}, P_Num = {} }
 MacroNums = { 1, 2, 3, 4, 5, 6, 7, 8 }
@@ -456,8 +427,32 @@ UtilityFXs = { 'Macros', 'JS: Macros /[.+', 'Frequency Spectrum Analyzer Meter',
 SpecialLayoutFXs = { 'VST: FabFilter Pro C 2 ', 'Pro Q 3', 'VST: FabFilter Pro Q 3 ', 'VST3: Pro Q 3 FabFilter',
     'VST3: Pro C 2 FabFilter', 'AU: Pro C 2 FabFilter' }
 
+------------------- General Settings --------------------------
 
+local function StoreSettings()
+    local data = tableToString(
+        {
+            reverse_scroll = Reverse_Scroll,
+            ctrl_scroll = Ctrl_Scroll,
+            proc_gr_native = ProC.GR_NATIVE,
+            proq_analyzer = ProQ.Analyzer
+        }
+    )
+    r.SetExtState("FXDEVICES", "Settings", data, true)
+end
 
+if r.HasExtState("FXDEVICES", "Settings") then
+    stored_data = r.GetExtState("FXDEVICES", "Settings")
+    if stored_data ~= nil then
+        local storedTable = stringToTable(stored_data)
+        if storedTable ~= nil then
+            Reverse_Scroll = storedTable.reverse_scroll
+            Ctrl_Scroll = storedTable.ctrl_scroll
+            ProC.GR_NATIVE = storedTable.proc_gr_native
+            ProQ.Analyzer = storedTable.proq_analyzer
+        end
+    end
+end
 
 
 
@@ -733,11 +728,25 @@ function FilterBox(FX_Idx, LyrID, SpaceIsBeforeRackMixer, FxGUID_Container, SpcI
                     MyText('VST', nil, clr)
                     SL()
                     HighlightSelectedItem(nil, clr, 0, L, T, R, B, h, w, 1, 1, 'GetItemRect')
+                elseif filtered_fx[i]:find('VSTi:') then
+                    local fx = filtered_fx[i]
+                    ShownName = fx:sub(6, (fx:find('.vsti') or 999) - 1)
+                    local clr = FX_Adder_VST or CustomColorsDefault.FX_Adder_VST
+                    MyText('VSTi', nil, clr)
+                    SL()
+                    HighlightSelectedItem(nil, clr, 0, L, T, R, B, h, w, 1, 1, 'GetItemRect')
                 elseif filtered_fx[i]:find('VST3:') then
                     local fx = filtered_fx[i]
                     ShownName = fx:sub(6) .. '##vst3'
                     local clr = FX_Adder_VST3 or CustomColorsDefault.FX_Adder_VST3
                     MyText('VST3', nil, clr)
+                    SL()
+                    HighlightSelectedItem(nil, clr, 0, L, T, R, B, h, w, 1, 1, 'GetItemRect')
+                elseif filtered_fx[i]:find('VST3i:') then
+                    local fx = filtered_fx[i]
+                    ShownName = fx:sub(7) .. '##vst3i'
+                    local clr = FX_Adder_VST3 or CustomColorsDefault.FX_Adder_VST3
+                    MyText('VST3i', nil, clr)
                     SL()
                     HighlightSelectedItem(nil, clr, 0, L, T, R, B, h, w, 1, 1, 'GetItemRect')
                 elseif filtered_fx[i]:find('JS:') then
@@ -759,6 +768,13 @@ function FilterBox(FX_Idx, LyrID, SpaceIsBeforeRackMixer, FxGUID_Container, SpcI
                     ShownName = fx:sub(6)
                     local clr = FX_Adder_CLAP or CustomColorsDefault.FX_Adder_CLAP
                     MyText('CLAP', nil, clr)
+                    SL()
+                    HighlightSelectedItem(nil, clr, 0, L, T, R, B, h, w, 1, 1, 'GetItemRect')
+                elseif filtered_fx[i]:find('CLAPi:') then
+                    local fx = filtered_fx[i]
+                    ShownName = fx:sub(7)
+                    local clr = FX_Adder_CLAP or CustomColorsDefault.FX_Adder_CLAP
+                    MyText('CLAPi', nil, clr)
                     SL()
                     HighlightSelectedItem(nil, clr, 0, L, T, R, B, h, w, 1, 1, 'GetItemRect')
                 elseif filtered_fx[i]:find('LV2:') then
@@ -847,7 +863,7 @@ end
 
 GetLTParam()
 
-ctx = r.ImGui_CreateContext('FX Device', r.ImGui_ConfigFlags_DockingEnable())
+ctx = r.ImGui_CreateContext('FX Devices', r.ImGui_ConfigFlags_DockingEnable())
 
 
 
@@ -873,8 +889,49 @@ end
 local script_folder = select(2, r.get_action_context()):match('^(.+)[\\//]')
 script_folder       = script_folder .. '/src'
 FontAwesome         = r.ImGui_CreateFont(script_folder .. '/IconFont1.ttf', 30)
-FontAwesome_small         = r.ImGui_CreateFont(script_folder .. '/IconFont1.ttf', 10)
+FontAwesome_small   = r.ImGui_CreateFont(script_folder .. '/IconFont1.ttf', 10)
 
+local function attachImagesAndFonts()
+    Img = {
+        Trash  = r.ImGui_CreateImage(CurrentDirectory .. '/src/Images/trash.png'),
+        Pin    = r.ImGui_CreateImage(CurrentDirectory .. '/src/Images/pin.png'),
+        Pinned = r.ImGui_CreateImage(CurrentDirectory .. '/src/Images/pinned.png'),
+        Copy   = r.ImGui_CreateImage(CurrentDirectory .. '/src/Images/copy.png'),
+        Paste  = r.ImGui_CreateImage(CurrentDirectory .. 'src/Images/paste.png'),
+        Save   = r.ImGui_CreateImage(CurrentDirectory .. '/src/Images/save.png'),
+        Sine   = r.ImGui_CreateImage(CurrentDirectory .. '/src/Images/sinewave.png'),
+    }
+    for i = 6, 64, 1 do
+        _G['Font_Andale_Mono_' .. i] = r.ImGui_CreateFont('andale mono', i)
+    end
+
+    Font_Andale_Mono_20_B = r.ImGui_CreateFont('andale mono', 20, r.ImGui_FontFlags_Bold()) -- TODO move to constants
+    r.ImGui_Attach(ctx, Font_Andale_Mono_20_B)
+    for i = 6, 64, 1 do
+        r.ImGui_Attach(ctx, _G['Font_Andale_Mono_' .. i])
+    end
+    r.ImGui_Attach(ctx, FontAwesome)
+    r.ImGui_Attach(ctx, FontAwesome_small)
+    for i, v in pairs(Img) do
+        r.ImGui_Attach(ctx, v)
+    end
+
+
+    for i = 6, 64, 1 do
+        _G['Arial_' .. i] = r.ImGui_CreateFont('Arial', i)
+        r.ImGui_Attach(ctx, _G['Arial_' .. i])
+    end
+
+    Arial = r.ImGui_CreateFont('Arial', 12) -- TODO move to constants
+end
+
+function TrashIcon(size, lbl, ClrBG, ClrTint)
+    local rv = r.ImGui_ImageButton(ctx, '##' .. lbl, Img.Trash, size, size, nil, nil, nil, nil, ClrBG, ClrTint) -- TODO weird but I can’t find anything in the official docs or the reaImGui repo about this function
+    if r.ImGui_IsItemHovered(ctx) then
+        TintClr = 0xCE1A28ff
+        return rv, TintClr
+    end
+end
 
 NumOfTotalTracks = r.CountTracks(0)
 -- Repeat for every track, at the beginning of script
@@ -886,65 +943,68 @@ for Track_Idx = 0, NumOfTotalTracks - 1, 1 do
     Trk[TrkID].Mod = {}
     Trk[TrkID].SEQL = Trk[TrkID].SEQL or {}
     Trk[TrkID].SEQ_Dnom = Trk[TrkID].SEQ_Dnom or {}
-    local AutoPrmCount =  GetTrkSavedInfo('How Many Automated Prm in Modulators', Track  )
+    local AutoPrmCount = GetTrkSavedInfo('How Many Automated Prm in Modulators', Track)
     Trk[TrkID].AutoPrms = Trk[TrkID].AutoPrms or {}
-    for i= 1, (AutoPrmCount or 0)+1, 1 do
-        Trk[TrkID].AutoPrms[i]= GetTrkSavedInfo('Auto Mod'..i, Track, 'str' )
+    for i = 1, (AutoPrmCount or 0) + 1, 1 do
+        Trk[TrkID].AutoPrms[i] = GetTrkSavedInfo('Auto Mod' .. i, Track, 'str')
     end
 
 
-    local function RC (str, type)
-        if type == 'str' then 
-            return select(2, r.GetSetMediaTrackInfo_String(Track, 'P_EXT: ' ..str, '', false))
-        else 
-            return tonumber(select(2, r.GetSetMediaTrackInfo_String(Track, 'P_EXT: ' ..str, '', false)))
+    local function RC(str, type)
+        if type == 'str' then
+            return select(2, r.GetSetMediaTrackInfo_String(Track, 'P_EXT: ' .. str, '', false))
+        else
+            return tonumber(select(2, r.GetSetMediaTrackInfo_String(Track, 'P_EXT: ' .. str, '', false)))
         end
     end
     for i = 1, 8, 1 do -- for every modulator
         Trk[TrkID].Mod[i] = {}
         local m = Trk[TrkID].Mod[i]
 
-        m.ATK = RC( 'Macro ' .. i .. ' Atk')
-        m.REL = RC( 'Macro ' .. i .. ' Rel')
+        m.ATK = RC('Macro ' .. i .. ' Atk')
+        m.REL = RC('Macro ' .. i .. ' Rel')
         Trk[TrkID].SEQL[i] = RC('Macro ' .. i .. ' SEQ Length')
-        Trk[TrkID].SEQ_Dnom[i] = RC( 'Macro ' .. i .. ' SEQ Denominator' )
-        m.Smooth =RC('Macro ' .. i .. ' Follower Speed' )
-        m.Gain = RC('Macro ' .. i .. ' Follower Gain' )
+        Trk[TrkID].SEQ_Dnom[i] = RC('Macro ' .. i .. ' SEQ Denominator')
+        m.Smooth = RC('Macro ' .. i .. ' Follower Speed')
+        m.Gain = RC('Macro ' .. i .. ' Follower Gain')
 
-        m.LFO_NodeCt = RC( 'Mod ' .. i..'Total Number of Nodes' )
-        m.LFO_spd = RC( 'Mod ' .. i..'LFO Speed' )
-        m.LFO_leng = RC( 'Mod ' .. i..'LFO Length' )
-        m.LFO_Env_or_Loop = RC('Mod ' .. i..'LFO_Env_or_Loop' )
-        m.Rel_Type = RC('Mod ' .. i..'LFO_Release_Type' )
-        if m.Rel_Type     == 0 then m.Rel_Type = 'Latch' 
-        elseif m.Rel_Type == 1 then m.Rel_Type = 'Simple Release' 
-        elseif m.Rel_Type == 2 then m.Rel_Type = 'Custom Release' 
-        elseif m.Rel_Type == 3 then m.Rel_Type = 'Custom Release - No Jump' 
+        m.LFO_NodeCt = RC('Mod ' .. i .. 'Total Number of Nodes')
+        m.LFO_spd = RC('Mod ' .. i .. 'LFO Speed')
+        m.LFO_leng = RC('Mod ' .. i .. 'LFO Length')
+        m.LFO_Env_or_Loop = RC('Mod ' .. i .. 'LFO_Env_or_Loop')
+        m.Rel_Type = RC('Mod ' .. i .. 'LFO_Release_Type')
+        if m.Rel_Type == 0 then
+            m.Rel_Type = 'Latch'
+        elseif m.Rel_Type == 1 then
+            m.Rel_Type = 'Simple Release'
+        elseif m.Rel_Type == 2 then
+            m.Rel_Type = 'Custom Release'
+        elseif m.Rel_Type == 3 then
+            m.Rel_Type = 'Custom Release - No Jump'
         end
 
-        if m.LFO_Env_or_Loop == 1 then m.LFO_Env_or_Loop = 'Envelope' else m.LFO_Env_or_Loop = nil end 
-        
+        if m.LFO_Env_or_Loop == 1 then m.LFO_Env_or_Loop = 'Envelope' else m.LFO_Env_or_Loop = nil end
 
 
-        for N=1, (m.LFO_NodeCt or 0) , 1 do 
-            
+
+        for N = 1, (m.LFO_NodeCt or 0), 1 do
             m.Node = m.Node or {}
             m.Node[N] = m.Node[N] or {}
-            m.Node[N].x = RC('Mod ' .. i..'Node '..N..' X')
+            m.Node[N].x = RC('Mod ' .. i .. 'Node ' .. N .. ' X')
 
 
-            m.Node[N].y = RC('Mod ' .. i..'Node '..N..' Y')    
-            m.Node[N].ctrlX  = RC('Mod ' .. i..'Node'..N..'Ctrl X')
+            m.Node[N].y       = RC('Mod ' .. i .. 'Node ' .. N .. ' Y')
+            m.Node[N].ctrlX   = RC('Mod ' .. i .. 'Node' .. N .. 'Ctrl X')
 
-            m.Node[N].ctrlY  = RC('Mod ' .. i..'Node'..N..'Ctrl Y')      
+            m.Node[N].ctrlY   = RC('Mod ' .. i .. 'Node' .. N .. 'Ctrl Y')
             m.NodeNeedConvert = true
         end
-        if RC('Mod ' .. i..'LFO_Rel_Node' ) then
-            local ID = RC('Mod ' .. i..'LFO_Rel_Node' )
+        if RC('Mod ' .. i .. 'LFO_Rel_Node') then
+            local ID = RC('Mod ' .. i .. 'LFO_Rel_Node')
             m.Node[ID] = m.Node[ID] or {}
-            m.Node[ID].Rel = true 
+            m.Node[ID].Rel = true
         end
-        
+
 
 
         Trk[TrkID].Mod[i].SEQ = Trk[TrkID].Mod[i].SEQ or {}
@@ -964,53 +1024,6 @@ for Track_Idx = 0, NumOfTotalTracks - 1, 1 do
     Trk[TrkID] = Trk[TrkID] or {}
     Trk[TrkID].PreFX = Trk[TrkID].PreFX or {}
     Trk[TrkID].PostFX = Trk[TrkID].PostFX or {}
-
-
-
-    function attachImagesAndFonts()
-
-        Img = {
-            Trash = r.ImGui_CreateImage(CurrentDirectory ..'/src/Images/trash.png');
-            Pin   = r.ImGui_CreateImage(CurrentDirectory ..'/src/Images/pin.png');
-            Pinned= r.ImGui_CreateImage(CurrentDirectory ..'/src/Images/pinned.png');
-            Copy  = r.ImGui_CreateImage(CurrentDirectory ..'/src/Images/copy.png');
-            Paste  = r.ImGui_CreateImage(CurrentDirectory ..'src/Images/paste.png');
-            Save  = r.ImGui_CreateImage(CurrentDirectory ..'/src/Images/save.png');
-            Sine  = r.ImGui_CreateImage(CurrentDirectory ..'/src/Images/sinewave.png');
-        }
-        for i = 6, 64, 1 do
-            _G['Font_Andale_Mono_' .. i] = r.ImGui_CreateFont('andale mono', i)
-        end
-
-        Font_Andale_Mono_20_B = r.ImGui_CreateFont('andale mono', 20, r.ImGui_FontFlags_Bold()) -- TODO move to constants
-        r.ImGui_Attach(ctx, Font_Andale_Mono_20_B)
-        for i = 6, 64, 1 do
-            r.ImGui_Attach(ctx, _G['Font_Andale_Mono_' .. i])
-        end
-        r.ImGui_Attach(ctx, FontAwesome)
-        r.ImGui_Attach(ctx, FontAwesome_small)
-        for i, v in pairs( Img) do 
-            r.ImGui_Attach(ctx, v)
-        end
-       
-
-
-
-        for i = 6, 64, 1 do
-            _G['Arial_' .. i] = r.ImGui_CreateFont('Arial', i)
-            r.ImGui_Attach(ctx, _G['Arial_' .. i])
-        end
-
-        Arial = r.ImGui_CreateFont('Arial', 12) -- TODO move to constants
-    end
-
-    function TrashIcon(size, lbl, ClrBG, ClrTint)
-        local rv = r.ImGui_ImageButton(ctx, '##' .. lbl, Img.Trash, size, size, nil, nil, nil, nil, ClrBG, ClrTint) -- TODO weird but I can’t find anything in the official docs or the reaImGui repo about this function
-        if r.ImGui_IsItemHovered(ctx) then
-            TintClr = 0xCE1A28ff
-            return rv, TintClr
-        end
-    end
 
     RetrieveFXsSavedLayout(FXCount)
 
@@ -1068,7 +1081,7 @@ for Track_Idx = 0, NumOfTotalTracks - 1, 1 do
     end
 
 
-    
+
 
     for FX_Idx = 0, FXCount - 1, 1 do --repeat as many times as fx instances
         local FxGUID = r.TrackFX_GetFXGUID(Track, FX_Idx)
@@ -1118,9 +1131,10 @@ for Track_Idx = 0, NumOfTotalTracks - 1, 1 do
             if FX[FxGUID].Unlink == 'Unlink' then FX[FxGUID].Unlink = true elseif FX[FxGUID].Unlink == '' then FX[FxGUID].Unlink = nil end
 
             --for Fx_P = 1, #FX[FxGUID] or 0, 1 do
-            for Fx_P in pairs(FX[FxGUID]) do 
-
-                FX[FxGUID][Fx_P].V = tonumber(select(2,r.GetSetMediaTrackInfo_String(Track, 'P_EXT: FX' .. FxGUID .. 'Prm' ..Fx_P .. 'Value before modulation', '', false)))
+            for Fx_P in pairs(FX[FxGUID]) do
+                FX[FxGUID][Fx_P].V = tonumber(select(2,
+                    r.GetSetMediaTrackInfo_String(Track,
+                        'P_EXT: FX' .. FxGUID .. 'Prm' .. Fx_P .. 'Value before modulation', '', false)))
 
 
                 local ParamX_Value = 'Param' ..
@@ -1159,12 +1173,13 @@ for Track_Idx = 0, NumOfTotalTracks - 1, 1 do
                     Trk[TrkID].Mod[m].Val = tonumber(select(2,
                         r.GetProjExtState(0, 'FX Devices', 'Macro' .. m .. 'Value of Track' .. TrkID)))
 
-                    FP.ModBypass = RemoveEmptyStr(select(2,r.GetSetMediaTrackInfo_String(Track, 'P_EXT: FX' .. FxGUID .. 'Prm' .. Fx_P .. 'Mod bypass', '',false)))
+                    FP.ModBypass = RemoveEmptyStr(select(2,
+                        r.GetSetMediaTrackInfo_String(Track, 'P_EXT: FX' .. FxGUID .. 'Prm' .. Fx_P .. 'Mod bypass', '',
+                            false)))
 
                     FP.ModBipolar = FP.ModBipolar or {}
-                    FP.ModBipolar[m] = StringToBool[ select(2,r.GetSetMediaTrackInfo_String(Track, 'P_EXT: FX' .. FxGUID .. 'Prm' .. Fx_P .. 'Macro' .. m.. 'Mod Bipolar', '',false))]
-
-
+                    FP.ModBipolar[m] = StringToBool
+                        [select(2, r.GetSetMediaTrackInfo_String(Track, 'P_EXT: FX' .. FxGUID .. 'Prm' .. Fx_P .. 'Macro' .. m .. 'Mod Bipolar', '', false))]
                 end
 
 
@@ -1283,11 +1298,24 @@ end
 
 ---------------------------- End For Before GUI ----------------------------
 
+local function Horizontal_Scroll(value)
+    if Reverse_Scroll then
+        Scroll_V = -Wheel_V
+    else
+        Scroll_V = Wheel_V
+    end
+    if -CursorStartX + Scroll_V * value < value then
+        r.ImGui_SetNextWindowScroll(ctx, 0, 0)                                -- scroll to the left side when scroll value is bigger than the rest space value
+    else
+        r.ImGui_SetNextWindowScroll(ctx, -CursorStartX + Scroll_V * value, 0) -- scroll horizontally
+    end
+end
+
 function loop()
     GetLT_FX_Num()
     GetLTParam()
     CheckDnDType() -- Defined in Layout Editor functions
-   
+    local focused_window, hwnd = GetFocusedWindow()
     if ChangeFont then
         r.ImGui_Attach(ctx, _G
             [(ChangeFont_Font or 'Font_Andale_Mono') .. '_' .. (ChangeFont_Size or ChangeFont.FtSize)])
@@ -1296,7 +1324,6 @@ function loop()
         ChangeFont_Font = nil
         ChangeFont_Var = nil
     end
-
 
 
 
@@ -1316,11 +1343,10 @@ function loop()
     r.ImGui_PushStyleColor(ctx, r.ImGui_Col_MenuBarBg(), TrkClr or 0x00000000)
     r.ImGui_PushStyleColor(ctx, r.ImGui_Col_WindowBg(), Window_BG or CustomColorsDefault.Window_BG)
     --------------------------==  BEGIN GUI----------------------------------------------------------------------------
-    local visible, open = r.ImGui_Begin(ctx, 'FX Device', true,
+    local visible, open = r.ImGui_Begin(ctx, 'FX Devices', true,
         r.ImGui_WindowFlags_NoScrollWithMouse() + r.ImGui_WindowFlags_NoScrollbar() + r.ImGui_WindowFlags_MenuBar() +
         r.ImGui_WindowFlags_NoCollapse() + r.ImGui_WindowFlags_NoNav())
     r.ImGui_PopStyleColor(ctx, 2) -- for menu  bar and window BG
-
 
     local Viewport = r.ImGui_GetWindowViewport(ctx)
     VP.w, VP.h     = r.ImGui_Viewport_GetSize(Viewport)
@@ -1387,10 +1413,10 @@ function loop()
         if LT_Track == nil then
             local Viewport = r.ImGui_GetWindowViewport(ctx)
 
-            r.ImGui_DrawList_AddTextEx(VP.FDL, Font_Andale_Mono_20_B, 20, VP.X, VP.Y + VP.h / 2, 0xffffffff, 'Select a track to start')
-        else -- of if LT_Track
-
-                r.gmem_write(4,0) -- set jsfx mode to none , telling it user is not making any changes, this prevents bipolar modulation from going back to unipolar by setting modamt from 100~101 back to 0~1
+            r.ImGui_DrawList_AddTextEx(VP.FDL, Font_Andale_Mono_20_B, 20, VP.X, VP.Y + VP.h / 2, 0xffffffff,
+                'Select a track to start')
+        else                   -- of if LT_Track
+            r.gmem_write(4, 0) -- set jsfx mode to none , telling it user is not making any changes, this prevents bipolar modulation from going back to unipolar by setting modamt from 100~101 back to 0~1
 
 
             HintMessage = nil
@@ -1399,11 +1425,11 @@ function loop()
             -- if action to record last touch is triggered
             if r.GetExtState('FXD', 'Record last touch') ~= '' then
                 if not IsPrmAlreadyAdded(true) then
-                    StoreNewParam(LT_FXGUID, LT_ParamName, LT_ParamNum, LT_FXNum,true)
+                    StoreNewParam(LT_FXGUID, LT_ParamName, LT_ParamNum, LT_FXNum, true)
                 end
                 r.SetExtState('FXD', 'Record last touch', '', false)
             end
-            
+
 
             ------- Add FX ---------
             for i, v in ipairs(AddFX.Name) do
@@ -1434,13 +1460,12 @@ function loop()
                     FX[SplittrID] = FX[SplittrID] or {}
                     FX[SplittrID].AttachToJoiner = JoinerID
                     r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Splitter\'s Joiner FxID ' .. SplittrID,
-                        JoinerID,true)
+                        JoinerID, true)
                 elseif v:find('FXD Gain Reduction Scope') then
                     local _, FX_Name = r.TrackFX_GetFXName(LT_Track, AddFX.Pos[i])
 
                     SyncAnalyzerPinWithFX(AddFX.Pos[i], AddFX.Pos[i] - 1, FX_Name)
                 end
-
             end
 
 
@@ -1498,15 +1523,14 @@ function loop()
                 MovFX = { FromPos = {}, ToPos = {}, Lbl = {}, Copy = {} }
                 NeedCopyFX = nil
                 DropPos = nil
-                
             end
 
 
 
-           --[[  if not init then 
+            --[[  if not init then
                 r.TrackFX_CopyToTrack(LT_Track, 1, LT_Track, 33554439, true)
-            end 
-            init = true 
+            end
+            init = true
  ]]
 
             --------- Don't remove this ---------
@@ -1552,7 +1576,6 @@ function loop()
             -- if user switch selected track...
             local layoutRetrieved
             if TrkID ~= TrkID_End then
-                
                 if TrkID_End ~= nil and TrkID ~= nil then
                     NumOfTotalTracks = r.CountTracks(0)
                     --[[  r.gmem_attach('TrackNameForMacro')
@@ -1565,14 +1588,14 @@ function loop()
                 end
 
                 RetrieveFXsSavedLayout(Sel_Track_FX_Count)
-                TREE = BuildFXTree(LT_Track )
+                TREE = BuildFXTree(LT_Track)
 
-                layoutRetrieved= true 
+                layoutRetrieved = true
                 SyncTrkPrmVtoActualValue()
                 LT_TrackNum = math.floor(r.GetMediaTrackInfo_Value(LT_Track, 'IP_TRACKNUMBER'))
             end
 
-            -- if new fx is added 
+            -- if new fx is added
             if RepeatTimeForWindows ~= r.TrackFX_GetCount(LT_Track) and not layoutRetrieved then
                 RetrieveFXsSavedLayout(Sel_Track_FX_Count)
                 --TREE = BuildFXTree(tr)
@@ -1643,21 +1666,16 @@ function loop()
                         Dock_Now = true
                     end
                 end
-                if select(2, r.ImGui_MenuItem(ctx,"Rescan Plugin List")) then
+                if r.ImGui_BeginMenu(ctx, "General Behavior") then
+                    _, Reverse_Scroll = r.ImGui_Checkbox(ctx, "Reverse Scroll", Reverse_Scroll)
+                    _, Ctrl_Scroll = r.ImGui_Checkbox(ctx, "Ctrl Scroll", Ctrl_Scroll)
+                    _, ProC.GR_NATIVE = r.ImGui_Checkbox(ctx, 'Use Native Gain Reduction for Pro-C', ProC.GR_NATIVE)
+                    _, ProQ.Analyzer = r.ImGui_Checkbox(ctx, 'Use analyzer for Pro-Q', ProQ.Analyzer)
+                    StoreSettings()
+                    r.ImGui_EndMenu(ctx)
+                end
+                if select(2, r.ImGui_MenuItem(ctx, "Rescan Plugin List")) then
                     FX_LIST, CAT = MakeFXFiles()
-                end
-
-                if r.ImGui_Checkbox( ctx, 'Use Native Gain Reduction for Pro-C', ProC.GR_NATIVE) then 
-                    ProC.GR_NATIVE = toggle(ProC.GR_NATIVE)
-                    r.SetExtState('FXD', 'Use Native Gain Reduction for Pro-C', tostring(ProC.GR_NATIVE) , true )
-                end
-
-               
-
-                if r.ImGui_Checkbox( ctx, 'Use analyzer for Pro-Q', ProQ.Analyzer) then 
-                    ProQ.Analyzer = toggle(ProQ.Analyzer)
-                    r.SetExtState('FXD', 'Use analyzer for Pro-Q', tostring(ProQ.Analyzer) , true )
-
                 end
 
                 MyText('Version : ' .. VersionNumber, font, 0x777777ff, WrapPosX)
@@ -1702,7 +1720,7 @@ function loop()
                 r.Undo_BeginBlock()
                 r.SetTrackAutomationMode(LT_Track, 0)
                 r.Undo_EndBlock('Set track automation mode (Trim/Read)', -1)
-            end 
+            end
             if r.ImGui_Button(ctx, 'T') then
                 r.Undo_BeginBlock()
                 r.SetTrackAutomationMode(LT_Track, 2)
@@ -1712,7 +1730,7 @@ function loop()
                 r.Undo_BeginBlock()
                 r.SetTrackAutomationMode(LT_Track, 5)
                 r.Undo_EndBlock('Set track automation mode (Latch Preview)', -1)
-            end  
+            end
 
 
 
@@ -1816,7 +1834,7 @@ function loop()
                 TryingToAddExistingPrm_Cont = nil
             end
 
-             FLT_MIN, FLT_MAX = r.ImGui_NumericLimits_Float()
+            FLT_MIN, FLT_MAX = r.ImGui_NumericLimits_Float()
 
 
             ------------------------------
@@ -2060,7 +2078,7 @@ function loop()
                     r.ImGui_TableSetColumnIndex(ctx, (i - 1) * 2) --r.ImGui_PushItemWidth( ctx, -FLT_MIN)
                     local Mc = Trk[TrkID].Mod[i]
                     r.gmem_attach('ParamValues')
-                    local CurrentPos       = r.gmem_read(108+Macro)  +1  --  +1 because to make zero-based start on 1
+                    local CurrentPos = r.gmem_read(108 + Macro) + 1 --  +1 because to make zero-based start on 1
 
 
                     --r.ImGui_SetNextItemWidth(ctx, 20)
@@ -2112,8 +2130,6 @@ function loop()
 
                             if Mods == Shift then DrgSpdMod = 4 end
                             if v ~= 0 then
-                                
-
                                 v = v * (-1)
                                 if not (S[St] == 1 and v > 0) and not (S[St] == 0 and v < 0) then
                                     S[St] = S[St] + v / 100
@@ -2145,17 +2161,16 @@ function loop()
 
                         r.ImGui_DrawList_AddRectFilled(Macros_WDL, L, T + H, L + W - 1, math.max(B - H * (S[St] or 0), T),
                             Clr)
-                        if CurrentPos == St  then -- if Step SEQ 'playhead' is now on current step
+                        if CurrentPos == St then -- if Step SEQ 'playhead' is now on current step
                             r.ImGui_DrawList_AddRect(Macros_WDL, L, T + H, L + W - 1, T, 0xffffff99)
                         end
                         SL(nil, 0)
-
                     end
 
 
 
                     r.ImGui_SetNextWindowPos(ctx, HdrPosL, VP.y - StepSEQ_H - 100)
-                    if Mc.AdjustingSteps and not r.ImGui_IsMouseDown(ctx, 0)  then  Mc.AdjustingSteps = nil end 
+                    if Mc.AdjustingSteps and not r.ImGui_IsMouseDown(ctx, 0) then Mc.AdjustingSteps = nil end
 
                     function open_SEQ_Win(Track, i)
                         if not HoveringSmoothness then
@@ -2286,20 +2301,20 @@ function loop()
                                     SL(nil, 0)
                                     local FillClr = 0x00000000
 
-                                    if r.ImGui_IsItemClicked(ctx ) then 
+                                    if r.ImGui_IsItemClicked(ctx) then
                                         Mc.AdjustingSteps = Macro
                                     end
-                                    local AdjustingStep 
-                                    if Mc.AdjustingSteps and  MsX >= L and MsX < R then  
+                                    local AdjustingStep
+                                    if Mc.AdjustingSteps and MsX >= L and MsX < R then
                                         AdjustingStep = St
                                     end
 
 
-                                    if AdjustingStep==St then
+                                    if AdjustingStep == St then
                                         --Calculate Value at Mouse pos
                                         local MsX, MsY = r.ImGui_GetMousePos(ctx)
 
-                                        S[St] = SetMinMax( ((B - MsY) / StepSEQ_H), 0, 1) --[[ *(-1) ]]
+                                        S[St] = SetMinMax(((B - MsY) / StepSEQ_H), 0, 1) --[[ *(-1) ]]
                                         r.gmem_write(4, 7)                        -- tells jsfx user is changing a step's value
                                         r.gmem_write(5, i)                        -- tells which macro user is tweaking
                                         r.gmem_write(112, SetMinMax(S[St], 0, 1)) -- tells the step's value
@@ -2307,8 +2322,6 @@ function loop()
 
                                         r.GetSetMediaTrackInfo_String(LT_Track,
                                             'P_EXT: Macro ' .. i .. ' SEQ Step = ' .. St .. ' Val', S[St], true)
-
-                                        
                                     elseif IsRBtnHeld and r.ImGui_IsMouseHoveringRect(ctx, L, T, R, B) and not SmallSEQActive then
                                         SEQ_RMB_Val = 0
                                         S[St] = SEQ_RMB_Val
@@ -2333,7 +2346,7 @@ function loop()
                                     r.ImGui_DrawList_AddRectFilled(WDL, L, T + StepSEQ_H, L + StepSEQ_W - 1,
                                         math.max(B - StepSEQ_H * (S[St] or 0), T), Clr)
 
-                                    if CurrentPos == St or ( CurrentPos ==0 and St ==(Trk[TrkID].SEQL[i] or SEQ_Default_Num_of_Steps)) then -- if Step SEQ 'playhead' is now on current step
+                                    if CurrentPos == St or (CurrentPos == 0 and St == (Trk[TrkID].SEQL[i] or SEQ_Default_Num_of_Steps)) then -- if Step SEQ 'playhead' is now on current step
                                         r.ImGui_DrawList_AddRect(WDL, L, B, L + StepSEQ_W - 1, T, 0xffffff88)
                                     end
                                 end
@@ -2454,91 +2467,92 @@ function loop()
                             notHoverFOL_Time = 0
                         end
                     end
-                elseif Trk[TrkID].Mod[i].Type == 'LFO' then  
+                elseif Trk[TrkID].Mod[i].Type == 'LFO' then
                     local function ChangeLFO(mode, V, gmem, StrName)
                         r.gmem_write(4, mode) -- tells jsfx user is adjusting LFO Freq
                         r.gmem_write(5, i)    -- Tells jsfx which macro
                         r.gmem_write(gmem or 9, V)
-                        if StrName then 
-                            r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Mod ' .. Macro..StrName , V, true)
+                        if StrName then
+                            r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Mod ' .. Macro .. StrName, V, true)
                         end
                     end
 
-                    local function SaveLFO(StrName,  V)
-                        if StrName then 
-                            r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Mod ' .. Macro..StrName , V, true)
+                    local function SaveLFO(StrName, V)
+                        if StrName then
+                            r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Mod ' .. Macro .. StrName, V, true)
                         end
                     end
-                    local H = 20
-                    local MOD = math.abs(SetMinMax((r.gmem_read(100 + i) or 0) / 127, -1, 1)) 
-                    LFO.DummyH  =  LFO.Win.h + 20
-                    --LFO.DummyW  =  ( LFO.Win.w + 30) * ((Mc.LFO_leng or LFO.Def.Len)/4 ) 
-                    Mc.Freq = Mc.Freq or 1
-                    Mc.Gain = Mc.Gain or 5
+                    local H    = 20
+                    local MOD  = math.abs(SetMinMax((r.gmem_read(100 + i) or 0) / 127, -1, 1))
+                    LFO.DummyH = LFO.Win.h + 20
+                    --LFO.DummyW  =  ( LFO.Win.w + 30) * ((Mc.LFO_leng or LFO.Def.Len)/4 )
+                    Mc.Freq    = Mc.Freq or 1
+                    Mc.Gain    = Mc.Gain or 5
                     r.ImGui_TableSetColumnIndex(ctx, (MacroNums[i] - 1) * 2)
                     --[[  IsMacroSlidersEdited, I.Val = r.ImGui_SliderDouble(ctx, i .. '##LFO', I.Val, Slider1Min or 0,
                     Slider1Max or 1) ]]
-                    
-                    local W = (VP.w - 10) / 12 -3
+
+                    local W = (VP.w - 10) / 12 - 3
                     local rv = r.ImGui_InvisibleButton(ctx, 'LFO Button' .. i, W, H)
                     local w, h = r.ImGui_GetItemRectSize(ctx)
-                    
+
                     local L, T = r.ImGui_GetItemRectMin(ctx)
                     local WDL = r.ImGui_GetWindowDrawList(ctx)
-                    local X_range =  (LFO.Win.w ) * ((Mc.LFO_leng or LFO.Def.Len)/4 )
+                    local X_range = (LFO.Win.w) * ((Mc.LFO_leng or LFO.Def.Len) / 4)
 
-                    r.ImGui_DrawList_AddRect(WDL, L, T-2, L + w +2, T + h, EightColors.LFO[i])
-                    
+                    r.ImGui_DrawList_AddRect(WDL, L, T - 2, L + w + 2, T + h, EightColors.LFO[i])
+
 
 
                     if r.ImGui_IsItemClicked(ctx, 1) and Mods == Ctrl then
                         r.ImGui_OpenPopup(ctx, 'LFO' .. i .. 'Menu')
-                    elseif rv and Mods == 0 then 
-                        if LFO.Pin == TrkID..'Macro = '..Macro then LFO.Pin =nil
-                        else  LFO.Pin = TrkID..'Macro = '..Macro
+                    elseif rv and Mods == 0 then
+                        if LFO.Pin == TrkID .. 'Macro = ' .. Macro then
+                            LFO.Pin = nil
+                        else
+                            LFO.Pin = TrkID .. 'Macro = ' .. Macro
                         end
-                    
                     end
 
                     WhenRightClickOnModulators(Macro)
-                    local G = 1  -- Gap between Drawing Coord values retrieved from jsfx
+                    local G = 1 -- Gap between Drawing Coord values retrieved from jsfx
                     local HdrPosL, HdrPosT = r.ImGui_GetCursorScreenPos(ctx)
-                    function DrawShape (Node, L, W, H, T, Clr )
-                        if Node then 
-                            for i, v  in ipairs(Node) do 
-
-                                local W, H = W or  w , H or h
+                    function DrawShape(Node, L, W, H, T, Clr)
+                        if Node then
+                            for i, v in ipairs(Node) do
+                                local W, H = W or w, H or h
 
 
                                 local N = Node
-                                local L = L or HdrPosL 
-                                local h =LFO.DummyH
-                                local lastX =  N[math.max(i-1,1)].x * W +L
-                                local lastY = T +H - (-N[math.max(i-1,1)].y + 1)  * H 
-    
-                                local x =  N[i].x  *W + L
-                                local y = T + H- (-N[math.min(i, #Node)].y+1)  *H 
-    
-                                local CtrlX =   (N[i].ctrlX or ((N[math.max(i-1,1)].x  + N[i].x) / 2)) * W + L
-                                local CtrlY =   T + H - (- (N[i].ctrlY or ((N[math.max(i-1,1)].y + N[i].y) / 2))+1) *H 
-    
-                                local PtsX, PtsY =  Curve_3pt_Bezier(lastX,lastY,CtrlX,CtrlY,x,y)
-    
-                                for i, v in ipairs(PtsX) do  
-                                    
-                                    if i > 1 and PtsX[i] <= L+W then      -- >1 because you need two points to draw a line
-                                        r.ImGui_DrawList_AddLine(WDL, PtsX[i-1] ,PtsY[i-1], PtsX[i],PtsY[i], Clr or EightColors.LFO[Macro])
+                                local L = L or HdrPosL
+                                local h = LFO.DummyH
+                                local lastX = N[math.max(i - 1, 1)].x * W + L
+                                local lastY = T + H - (-N[math.max(i - 1, 1)].y + 1) * H
+
+                                local x = N[i].x * W + L
+                                local y = T + H - (-N[math.min(i, #Node)].y + 1) * H
+
+                                local CtrlX = (N[i].ctrlX or ((N[math.max(i - 1, 1)].x + N[i].x) / 2)) * W + L
+                                local CtrlY = T + H - (-(N[i].ctrlY or ((N[math.max(i - 1, 1)].y + N[i].y) / 2)) + 1) * H
+
+                                local PtsX, PtsY = Curve_3pt_Bezier(lastX, lastY, CtrlX, CtrlY, x, y)
+
+                                for i, v in ipairs(PtsX) do
+                                    if i > 1 and PtsX[i] <= L + W then -- >1 because you need two points to draw a line
+                                        r.ImGui_DrawList_AddLine(WDL, PtsX[i - 1], PtsY[i - 1], PtsX[i], PtsY[i],
+                                            Clr or EightColors.LFO[Macro])
                                     end
                                 end
                             end
                         end
                     end
-                    -- Draw Tiny Playhead
-                    local PlayPos = L + r.gmem_read(108+i)/4 * w / ((Mc.LFO_leng or LFO.Def.Len)/4 )
-                    r.ImGui_DrawList_AddLine(WDL ,PlayPos , T ,PlayPos, T+h , EightColors.LFO[Macro], 1 )
-                    r.ImGui_DrawList_AddCircleFilled(WDL,PlayPos, T+ h -  MOD * h - 3/2 , 3, EightColors.LFO[Macro])
 
-                    DrawShape (Mc.Node, HdrPosL, w, h, T  )
+                    -- Draw Tiny Playhead
+                    local PlayPos = L + r.gmem_read(108 + i) / 4 * w / ((Mc.LFO_leng or LFO.Def.Len) / 4)
+                    r.ImGui_DrawList_AddLine(WDL, PlayPos, T, PlayPos, T + h, EightColors.LFO[Macro], 1)
+                    r.ImGui_DrawList_AddCircleFilled(WDL, PlayPos, T + h - MOD * h - 3 / 2, 3, EightColors.LFO[Macro])
+
+                    DrawShape(Mc.Node, HdrPosL, w, h, T)
 
 
                     if rv and not LFO_DragDir and Mods == 0 then
@@ -2546,23 +2560,22 @@ function loop()
                         --r.ImGui_SetNextWindowSize(ctx, LFO.Win.w  , LFO.Win.h+200)
                     end
 
-             
-                     
+
+
                     function open_LFO_Win(Track, Macro)
                         local tweaking
-                       -- r.ImGui_SetNextWindowSize(ctx, LFO.Win.w +20 , LFO.Win.h + 50)
+                        -- r.ImGui_SetNextWindowSize(ctx, LFO.Win.w +20 , LFO.Win.h + 50)
                         r.ImGui_SetNextWindowPos(ctx, HdrPosL, VP.y - 385)
-                        if r.ImGui_Begin(ctx, 'LFO Shape Edit Window'..Macro, true , r.ImGui_WindowFlags_NoDecoration()+ r.ImGui_WindowFlags_AlwaysAutoResize()) then
-
+                        if r.ImGui_Begin(ctx, 'LFO Shape Edit Window' .. Macro, true, r.ImGui_WindowFlags_NoDecoration() + r.ImGui_WindowFlags_AlwaysAutoResize()) then
                             local Node = Trk[TrkID].Mod[i].Node
-                            local function ConverCtrlNodeY (lastY, Y) 
-                                local Range = (math.max(lastY, Y) - math.min(lastY, Y)) 
-                                local NormV = (math.min(lastY, Y)+ Range - Y) / Range
-                                local Bipolar = -1 + (NormV  )* 2
+                            local function ConverCtrlNodeY(lastY, Y)
+                                local Range = (math.max(lastY, Y) - math.min(lastY, Y))
+                                local NormV = (math.min(lastY, Y) + Range - Y) / Range
+                                local Bipolar = -1 + (NormV) * 2
                                 return NormV
                             end
 
-                    
+
 
                             --Mc.Node = Mc.Node or { x = {} , ctrlX = {}, y = {}  , ctrlY = {}}
                             --[[ if not Node[i].x then
@@ -2571,15 +2584,16 @@ function loop()
                                 table.insert(Node.y, T + h / 2)
                                 table.insert(Node.y, T + h / 2)
                             end ]]
-                            local BtnSz=11
+                            local BtnSz = 11
 
-                            LFO.Pin = PinIcon (LFO.Pin,TrkID..'Macro = '..Macro  ,BtnSz, 'LFO window pin'..Macro, 0x00000000, ClrTint)
+                            LFO.Pin = PinIcon(LFO.Pin, TrkID .. 'Macro = ' .. Macro, BtnSz, 'LFO window pin' .. Macro,
+                                0x00000000, ClrTint)
                             SL()
 
-                            
-                            if r.ImGui_ImageButton(ctx, '## copy' .. Macro, Img.Copy, BtnSz, BtnSz, nil, nil, nil, nil, ClrBG, ClrTint) then 
+
+                            if r.ImGui_ImageButton(ctx, '## copy' .. Macro, Img.Copy, BtnSz, BtnSz, nil, nil, nil, nil, ClrBG, ClrTint) then
                                 LFO.Clipboard = {}
-                                for i , v in ipairs(Node)  do 
+                                for i, v in ipairs(Node) do
                                     LFO.Clipboard[i] = LFO.Clipboard[i] or {}
                                     LFO.Clipboard[i].x = v.x
                                     LFO.Clipboard[i].y = v.y
@@ -2587,62 +2601,63 @@ function loop()
                             end
 
                             SL()
-                            if not LFO.Clipboard then r.ImGui_BeginDisabled(ctx) end 
+                            if not LFO.Clipboard then r.ImGui_BeginDisabled(ctx) end
                             if r.ImGui_ImageButton(ctx, '## paste' .. Macro, Img.Paste, BtnSz, BtnSz, nil, nil, nil, nil, ClrBG, ClrTint) then
-                                for i , v in ipairs(LFO.Clipboard)  do 
-                                    Mc.Node[i] =  Mc.Node[i] or {}
+                                for i, v in ipairs(LFO.Clipboard) do
+                                    Mc.Node[i] = Mc.Node[i] or {}
                                     Mc.Node[i].x = v.x
                                     Mc.Node[i].y = v.y
                                 end
                             end
-                            if not LFO.Clipboard then r.ImGui_EndDisabled(ctx) end 
+                            if not LFO.Clipboard then r.ImGui_EndDisabled(ctx) end
 
                             SL()
                             r.ImGui_SetNextItemWidth(ctx, 100)
-                            if r.ImGui_BeginCombo( ctx, '## Env_Or_Loop'..Macro, Mc.LFO_Env_or_Loop or 'Loop') then
-                                if r.ImGui_Selectable( ctx, 'Loop',  p_1selected,   flagsIn,   size_wIn,   size_hIn) then 
-                                    Mc.LFO_Env_or_Loop = 'Loop' 
-                                    ChangeLFO(18, 0 , nil, 'LFO_Env_or_Loop') -- value is 0 because loop is default
+                            if r.ImGui_BeginCombo(ctx, '## Env_Or_Loop' .. Macro, Mc.LFO_Env_or_Loop or 'Loop') then
+                                if r.ImGui_Selectable(ctx, 'Loop', p_1selected, flagsIn, size_wIn, size_hIn) then
+                                    Mc.LFO_Env_or_Loop = 'Loop'
+                                    ChangeLFO(18, 0, nil, 'LFO_Env_or_Loop') -- value is 0 because loop is default
                                 end
-                                if r.ImGui_Selectable( ctx, 'Envelope (MIDI)',  p_2selected, flagsIn,   size_wIn,   size_hIn) then 
-                                    Mc.LFO_Env_or_Loop = 'Envelope' 
-                                    ChangeLFO(18, 1 , nil, 'LFO_Env_or_Loop') -- 1 for envelope
+                                if r.ImGui_Selectable(ctx, 'Envelope (MIDI)', p_2selected, flagsIn, size_wIn, size_hIn) then
+                                    Mc.LFO_Env_or_Loop = 'Envelope'
+                                    ChangeLFO(18, 1, nil, 'LFO_Env_or_Loop') -- 1 for envelope
                                 end
-                                tweaking = Macro 
+                                tweaking = Macro
                                 r.ImGui_EndCombo(ctx)
                             end
 
-                            if Mc.LFO_Env_or_Loop == 'Envelope'  then 
+                            if Mc.LFO_Env_or_Loop == 'Envelope' then
                                 SL()
                                 r.ImGui_SetNextItemWidth(ctx, 120)
                                 local ShownName
-                                if Mc.Rel_Type == 'Custom Release - No Jump' then ShownName = 'Custom No Jump' end 
-                                if r.ImGui_BeginCombo( ctx, '## ReleaseType'..Macro, ShownName or Mc.Rel_Type or 'Latch') then
-                                    tweaking = Macro 
-                                    if r.ImGui_Selectable( ctx, 'Latch',  p_1selected,   flagsIn,   size_wIn,   size_hIn) then 
+                                if Mc.Rel_Type == 'Custom Release - No Jump' then ShownName = 'Custom No Jump' end
+                                if r.ImGui_BeginCombo(ctx, '## ReleaseType' .. Macro, ShownName or Mc.Rel_Type or 'Latch') then
+                                    tweaking = Macro
+                                    if r.ImGui_Selectable(ctx, 'Latch', p_1selected, flagsIn, size_wIn, size_hIn) then
                                         Mc.Rel_Type = 'Latch'
                                         ChangeLFO(19, 0, nil, 'LFO_Release_Type') -- 1 for latch
-                                    end 
-                                    QuestionHelpHint ( 'Latch on to whichever value its at when midi key is released ' )
-                                    --[[ if r.ImGui_Selectable( ctx, 'Simple Release',  p_1selected,   flagsIn,   size_wIn,   size_hIn) then 
+                                    end
+                                    QuestionHelpHint('Latch on to whichever value its at when midi key is released ')
+                                    --[[ if r.ImGui_Selectable( ctx, 'Simple Release',  p_1selected,   flagsIn,   size_wIn,   size_hIn) then
                                         Mc.Rel_Type = 'Simple Release'
                                         ChangeLFO(19, 1 , nil, 'LFO_Release_Type') -- 1 for Simple release
                                     end   ]]
-                                    if r.ImGui_Selectable( ctx, 'Custom Release',  p_1selected,   flagsIn,   size_wIn,   size_hIn) then 
+                                    if r.ImGui_Selectable(ctx, 'Custom Release', p_1selected, flagsIn, size_wIn, size_hIn) then
                                         Mc.Rel_Type = 'Custom Release'
-                                        ChangeLFO(19, 2 , nil, 'LFO_Release_Type') -- 2 for Custom release
-                                    end  
-                                    QuestionHelpHint ( 'Jump to release node when midi note is released' )
+                                        ChangeLFO(19, 2, nil, 'LFO_Release_Type') -- 2 for Custom release
+                                    end
+                                    QuestionHelpHint('Jump to release node when midi note is released')
 
-                                    if r.ImGui_Selectable( ctx, 'Custom Release - No Jump',  p_1selected,   flagsIn,   size_wIn,   size_hIn) then 
+                                    if r.ImGui_Selectable(ctx, 'Custom Release - No Jump', p_1selected, flagsIn, size_wIn, size_hIn) then
                                         Mc.Rel_Type = 'Custom Release - No Jump'
-                                        ChangeLFO(19, 3 , nil, 'LFO_Release_Type') -- 3 for Custom release no jump
-                                    end  
-                                    QuestionHelpHint ( 'Custom release, but will prevent values jumping by scaling the part after the release node to fit value when midi key was released' )
+                                        ChangeLFO(19, 3, nil, 'LFO_Release_Type') -- 3 for Custom release no jump
+                                    end
+                                    QuestionHelpHint(
+                                        'Custom release, but will prevent values jumping by scaling the part after the release node to fit value when midi key was released')
 
-                                    if r.ImGui_Checkbox( ctx, 'Legato', Mc.LFO_Legato) then 
+                                    if r.ImGui_Checkbox(ctx, 'Legato', Mc.LFO_Legato) then
                                         Mc.LFO_Legato = toggle(Mc.LFO_Legato)
-                                        ChangeLFO(21, 1 , nil, 'LFO_Legato')
+                                        ChangeLFO(21, 1, nil, 'LFO_Legato')
                                     end
 
                                     r.ImGui_EndCombo(ctx)
@@ -2651,37 +2666,38 @@ function loop()
 
 
                             SL(nil, 30)
-                            if r.ImGui_ImageButton(ctx, '## save' .. Macro, Img.Save, BtnSz, BtnSz, nil, nil, nil, nil, ClrBG, ClrTint) then 
-                                  LFO.OpenSaveDialog= Macro 
+                            if r.ImGui_ImageButton(ctx, '## save' .. Macro, Img.Save, BtnSz, BtnSz, nil, nil, nil, nil, ClrBG, ClrTint) then
+                                LFO.OpenSaveDialog = Macro
                             end
 
                             SL()
 
 
-                            if r.ImGui_ImageButton(ctx, '## shape Preset' .. Macro, Img.Sine, BtnSz*2, BtnSz, nil, nil, nil, nil, 0xffffff00, ClrTint) then 
-                                if LFO.OpenShapeSelect then LFO.OpenShapeSelect = nil else LFO.OpenShapeSelect = Macro end 
-                            end 
-                            if LFO.OpenShapeSelect then Highlight_Itm(WDL, 0xffffff55 ) end 
+                            if r.ImGui_ImageButton(ctx, '## shape Preset' .. Macro, Img.Sine, BtnSz * 2, BtnSz, nil, nil, nil, nil, 0xffffff00, ClrTint) then
+                                if LFO.OpenShapeSelect then LFO.OpenShapeSelect = nil else LFO.OpenShapeSelect = Macro end
+                            end
+                            if LFO.OpenShapeSelect then Highlight_Itm(WDL, 0xffffff55) end
 
 
-                            r.ImGui_Dummy(ctx, (LFO.Win.w ) * ((Mc.LFO_leng or LFO.Def.Len)/4 ) ,  LFO.DummyH)
+                            r.ImGui_Dummy(ctx, (LFO.Win.w) * ((Mc.LFO_leng or LFO.Def.Len) / 4), LFO.DummyH)
                             --local old_Win_T, old_Win_B = VP.y - 320, VP.y - 20
                             local NodeSz = 15
                             local w, h = r.ImGui_GetItemRectSize(ctx)
-                            LFO.Def.DummyW = (LFO.Win.w ) * (LFO.Def.Len/4)
+                            LFO.Def.DummyW = (LFO.Win.w) * (LFO.Def.Len / 4)
                             LFO.DummyW = w
                             local L, T = r.ImGui_GetItemRectMin(ctx)
-                            local Win_T, Win_B = T  , T+h     -- 7 is prob the window padding
+                            local Win_T, Win_B = T, T + h -- 7 is prob the window padding
                             local Win_L = L
-                            r.ImGui_DrawList_AddRectFilled(WDL , L, T, L+w, T+h , 0xffffff22)   
+                            r.ImGui_DrawList_AddRectFilled(WDL, L, T, L + w, T + h, 0xffffff22)
                             SL()
-                            r.ImGui_Dummy(ctx, 10,  10)
+                            r.ImGui_Dummy(ctx, 10, 10)
 
 
-                            LFO.Win.L, LFO.Win.R = L , L + X_range
+                            LFO.Win.L, LFO.Win.R = L, L + X_range
                             local LineClr, CtClr = 0xffffff99, 0xffffff44
 
-                            Mc.Node = Mc.Node or {{x=0 , y = 0 },{x=1, y = 1 } } -- create two default tables for first and last point
+                            Mc.Node = Mc.Node or
+                                { { x = 0, y = 0 }, { x = 1, y = 1 } } -- create two default tables for first and last point
                             local Node = Mc.Node
 
 
@@ -2691,16 +2707,16 @@ function loop()
                                 return NormX, NormY
                             end
 
-                            local function Save_All_LFO_Info(Node) 
-                                for i, v in ipairs( Node) do 
-                                    if v.ctrlX  then 
-                                        SaveLFO('Node'..i..'Ctrl X', Node[i].ctrlX)
-                                        SaveLFO('Node'..i..'Ctrl Y', Node[i].ctrlY)
+                            local function Save_All_LFO_Info(Node)
+                                for i, v in ipairs(Node) do
+                                    if v.ctrlX then
+                                        SaveLFO('Node' .. i .. 'Ctrl X', Node[i].ctrlX)
+                                        SaveLFO('Node' .. i .. 'Ctrl Y', Node[i].ctrlY)
                                     end
 
-                                    SaveLFO('Node '..i..' X', Node[i].x)
-                                    SaveLFO('Node '..i..' Y',Node[i].y)
-                                    SaveLFO('Total Number of Nodes', #Node )
+                                    SaveLFO('Node ' .. i .. ' X', Node[i].x)
+                                    SaveLFO('Node ' .. i .. ' Y', Node[i].y)
+                                    SaveLFO('Total Number of Nodes', #Node)
                                 end
                             end
 
@@ -2708,18 +2724,18 @@ function loop()
 
                             Mc.NodeNeedConvert = Mc.NodeNeedConvert or nil
 
-                            --[[ if Mc.NodeNeedConvert then 
+                            --[[ if Mc.NodeNeedConvert then
 
-                                for N=1, (Mc.LFO_NodeCt or 0) , 1 do 
+                                for N=1, (Mc.LFO_NodeCt or 0) , 1 do
 
                                         Node[N] = Node[N] or {}
-                                    if Node[N].x then 
+                                    if Node[N].x then
                                         Node[N].x = Node[N].x * LFO.Win.w + HdrPosL
                                         Node[N].y = T +  (-Node[N].y+1) * h
                                     end
-                                    if Node[N].ctrlX and Node[N].ctrlY then 
-                                        Node[N].ctrlX = Node[N].ctrlX* (LFO.Win.w) + LFO.Win.L  
-                                        Node[N].ctrlY = Win_T + (-Node[N].ctrlY+1) * LFO.Win.h 
+                                    if Node[N].ctrlX and Node[N].ctrlY then
+                                        Node[N].ctrlX = Node[N].ctrlX* (LFO.Win.w) + LFO.Win.L
+                                        Node[N].ctrlY = Win_T + (-Node[N].ctrlY+1) * LFO.Win.h
                                     end
                                 end
                                 Mc.NodeNeedConvert=nil
@@ -2729,95 +2745,88 @@ function loop()
                             if not r.ImGui_IsAnyItemHovered(ctx) and LBtnDC then -- Add new node if double click
                                 local x, y = r.ImGui_GetMousePos(ctx)
                                 local InsertPos
-                                local x = (x - L)/ LFO.DummyW
-                                local y = (y - T)/ LFO.DummyH
+                                local x = (x - L) / LFO.DummyW
+                                local y = (y - T) / LFO.DummyH
 
 
                                 for i = 1, #Node, 1 do
                                     if i ~= #Node then
-                                        if Node[i].x < x and Node[i+1].x > x then InsertPos = i + 1 end
-
-                                    elseif not InsertPos then 
-                                        if Node[1].x > x  then InsertPos = 1           -- if it's before the first node
+                                        if Node[i].x < x and Node[i + 1].x > x then InsertPos = i + 1 end
+                                    elseif not InsertPos then
+                                        if Node[1].x > x then
+                                            InsertPos = 1 -- if it's before the first node
                                             --[[ table.insert(Node.ctrlX, InsertPos, HdrPosL + (x-HdrPosL)/2)
                                             table.insert(Node.ctrlY, InsertPos, y) ]]
-
-                
-                                        elseif Node[i].x < x then InsertPos = i + 1
-
-                                        elseif Node[i].x > x then InsertPos  = i 
+                                        elseif Node[i].x < x then
+                                            InsertPos = i + 1
+                                        elseif Node[i].x > x then
+                                            InsertPos = i
                                         end
-                                        
-
-
                                     end
-
-                                
                                 end
 
                                 table.insert(Node, InsertPos, {
-                                    x= SetMinMax(x, 0, 1);
-                                    y= SetMinMax(y, 0, 1);
+                                    x = SetMinMax(x, 0, 1),
+                                    y = SetMinMax(y, 0, 1),
                                 })
-                                
-                                Save_All_LFO_Info(Node) 
+
+                                Save_All_LFO_Info(Node)
                             end
 
-                            
+
                             local function AddNode(x, y, ID)
-                                
                                 local w, h = 15, 15
                                 InvisiBtn(ctx, x, y, '##Node' .. ID, 15)
                                 local Hvred
                                 local w, h = r.ImGui_GetItemRectSize(ctx)
                                 local L, T = r.ImGui_GetItemRectMin(ctx)
 
-                                local function ClampCtrlNode (ID)
-                                    Node[ID] = Node[ID]  or {}
+                                local function ClampCtrlNode(ID)
+                                    Node[ID] = Node[ID] or {}
 
                                     if Node[ID].ctrlX then
-                                        local lastX = Node[ID-1].x or 0
-                                        local lastY, Y = Node[ID-1].y or Node[ID].y , Node[ID].y
+                                        local lastX = Node[ID - 1].x or 0
+                                        local lastY, Y = Node[ID - 1].y or Node[ID].y, Node[ID].y
 
 
                                         -- Segment Before the tweaking point
-                                        if Node[ID].ctrlX and Node[ID].ctrlY then 
-                                            Node[ID].ctrlX = SetMinMax(Node[ID].ctrlX, lastX , Node[ID].x)
-                                            Node[ID].ctrlY = SetMinMax(Node[ID].ctrlY, math.min(lastY, Y), math.max(lastY, Y))
+                                        if Node[ID].ctrlX and Node[ID].ctrlY then
+                                            Node[ID].ctrlX = SetMinMax(Node[ID].ctrlX, lastX, Node[ID].x)
+                                            Node[ID].ctrlY = SetMinMax(Node[ID].ctrlY, math.min(lastY, Y),
+                                                math.max(lastY, Y))
 
-                                            SaveLFO('Node'..ID..'Ctrl X',Node[ID].ctrlX)
-                                            SaveLFO('Node'..ID..'Ctrl Y', Node[ID].ctrlY)
+                                            SaveLFO('Node' .. ID .. 'Ctrl X', Node[ID].ctrlX)
+                                            SaveLFO('Node' .. ID .. 'Ctrl Y', Node[ID].ctrlY)
                                         end
                                     end
                                 end
                                 function findRelNode()
-                                    for i, v in ipairs(Mc.Node) do 
-                                        if v.Rel == true then return i end 
+                                    for i, v in ipairs(Mc.Node) do
+                                        if v.Rel == true then return i end
                                     end
                                 end
 
-
-                                if (Mc.Rel_Type or ''):find( 'Custom Release') then 
-                                    if not findRelNode() then 
-                                        Node[#Mc.Node].Rel = true 
-                                        ChangeLFO(20, #Mc.Node, nil, 'LFO_Rel_Node') 
-                                    end     
-
-                                    if  r.ImGui_IsItemClicked(ctx,1) and Mods == Alt then 
-                                        Mc.Node[findRelNode() or 1].Rel=nil
-                                        Mc.Node[ID].Rel = true 
-                                        ChangeLFO(20, ID, nil, 'LFO_Rel_Node')  
+                                if (Mc.Rel_Type or ''):find('Custom Release') then
+                                    if not findRelNode() then
+                                        Node[#Mc.Node].Rel = true
+                                        ChangeLFO(20, #Mc.Node, nil, 'LFO_Rel_Node')
                                     end
-                                    if Mc.Node[ID].Rel then 
+
+                                    if r.ImGui_IsItemClicked(ctx, 1) and Mods == Alt then
+                                        Mc.Node[findRelNode() or 1].Rel = nil
+                                        Mc.Node[ID].Rel = true
+                                        ChangeLFO(20, ID, nil, 'LFO_Rel_Node')
+                                    end
+                                    if Mc.Node[ID].Rel then
                                         local L = L + NodeSz / 2
-                                        r.ImGui_DrawList_AddCircle(WDL, L , T + NodeSz / 2, 6, 0xffffffaa)
-                                        r.ImGui_DrawList_AddLine(WDL, L ,Win_T , L, Win_B , 0xffffff55 , 3 )
-                                        r.ImGui_DrawList_AddText(WDL, math.min(L, Win_L+ LFO.DummyW -50  ), Win_T, 0xffffffaa, 'Release')
-    
+                                        r.ImGui_DrawList_AddCircle(WDL, L, T + NodeSz / 2, 6, 0xffffffaa)
+                                        r.ImGui_DrawList_AddLine(WDL, L, Win_T, L, Win_B, 0xffffff55, 3)
+                                        r.ImGui_DrawList_AddText(WDL, math.min(L, Win_L + LFO.DummyW - 50), Win_T,
+                                            0xffffffaa, 'Release')
                                     end
                                 end
-                                
-                                
+
+
 
                                 if r.ImGui_IsItemHovered(ctx) then
                                     LineClr, CtClr = 0xffffffbb, 0xffffff88
@@ -2825,42 +2834,42 @@ function loop()
                                     Hvred = true
                                 end
 
-                                if MouseClosestNode==ID and r.ImGui_IsKeyPressed(ctx,r.ImGui_Key_X(),false) then 
+                                if MouseClosestNode == ID and r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_X(), false) then
                                     DraggingNode = ID
-                                    tweaking = Macro 
-                                elseif r.ImGui_IsKeyReleased(ctx,r.ImGui_Key_X())  then 
-                                    DraggingNode=nil
-                                end 
+                                    tweaking = Macro
+                                elseif r.ImGui_IsKeyReleased(ctx, r.ImGui_Key_X()) then
+                                    DraggingNode = nil
+                                end
 
                                 -- if moving node
-                                if (r.ImGui_IsItemActive(ctx) and Mods == 0)  or DraggingNode == ID then 
+                                if (r.ImGui_IsItemActive(ctx) and Mods == 0) or DraggingNode == ID then
                                     tweaking = Macro
-                                    HideCursorTillMouseUp(nil, r.ImGui_Key_X() )
+                                    HideCursorTillMouseUp(nil, r.ImGui_Key_X())
                                     HideCursorTillMouseUp(0)
                                     HoverNode = ID
-                                    Send_All_Coord ()
+                                    Send_All_Coord()
 
-                                    local lastX = Node[math.max (ID-1, 1)].x 
-                                    local nextX = Node[math.min (ID+1, #Node)].x
-                                    if ID ==1 then lastX = 0 end 
-                                    if ID == #Node then nextX = 1 end 
+                                    local lastX = Node[math.max(ID - 1, 1)].x
+                                    local nextX = Node[math.min(ID + 1, #Node)].x
+                                    if ID == 1 then lastX = 0 end
+                                    if ID == #Node then nextX = 1 end
 
-                                    local MsX, MsY =  GetMouseDelta(0, r.ImGui_Key_X())
+                                    local MsX, MsY = GetMouseDelta(0, r.ImGui_Key_X())
                                     local MsX = MsX / LFO.DummyW
                                     local MsY = MsY / LFO.DummyH
 
 
-                                    Node[ID].x = SetMinMax(Node[ID].x + MsX,  lastX, nextX)
+                                    Node[ID].x = SetMinMax(Node[ID].x + MsX, lastX, nextX)
                                     Node[ID].y = SetMinMax(Node[ID].y + MsY, 0, 1)
 
 
-                                    if ID == 1 then 
-                                        ClampCtrlNode (ID-1) 
+                                    if ID == 1 then
+                                        ClampCtrlNode(ID - 1)
                                     end
 
-                                    ClampCtrlNode (ID)
-                                    ClampCtrlNode (math.min (ID+1, #Node))
-                                    
+                                    ClampCtrlNode(ID)
+                                    ClampCtrlNode(math.min(ID + 1, #Node))
+
 
                                     --[[ ChangeLFO(13, NormX, 9, 'Node '..ID..' X')
                                     ChangeLFO(13, NormY, 10, 'Node '..ID..' Y')
@@ -2868,21 +2877,21 @@ function loop()
                                     ChangeLFO(13, #Node.x, 12, 'Total Number of Nodes' ) ]]
                                     local NormX, NormY = GetNormV(ID)
 
-                                    SaveLFO('Node '..ID..' X', Node[ID].x)
-                                    SaveLFO('Node '..ID..' Y',Node[ID].y)
-                                    SaveLFO('Total Number of Nodes', #Node )
+                                    SaveLFO('Node ' .. ID .. ' X', Node[ID].x)
+                                    SaveLFO('Node ' .. ID .. ' Y', Node[ID].y)
+                                    SaveLFO('Total Number of Nodes', #Node)
 
 
                                     if ID ~= #Node then
-                                        local this, next = Node[ID].x, Node[ID+1].x or 1
-                                        Node[ID+1].ctrlX = SetMinMax(Node[ID+1].ctrlX or (this + next) / 2, this, next)
-                                        if Node[ID+1].ctrlX == (this + next) / 2 then Node[ID+1].ctrlX = nil end
+                                        local this, next = Node[ID].x, Node[ID + 1].x or 1
+                                        Node[ID + 1].ctrlX = SetMinMax(Node[ID + 1].ctrlX or (this + next) / 2, this,
+                                            next)
+                                        if Node[ID + 1].ctrlX == (this + next) / 2 then Node[ID + 1].ctrlX = nil end
                                     end
 
                                     r.ImGui_ResetMouseDragDelta(ctx)
-                                elseif r.ImGui_IsItemClicked(ctx) and Mods == Alt then 
-
-                                    LFO.DeleteNode = ID 
+                                elseif r.ImGui_IsItemClicked(ctx) and Mods == Alt then
+                                    LFO.DeleteNode = ID
                                 end
 
 
@@ -2891,41 +2900,41 @@ function loop()
                                 return Hvred
                             end
                             local Node = Mc.Node
-                            
+
 
 
                             local FDL = r.ImGui_GetForegroundDrawList(ctx)
                             --table.sort(Node.x, function(k1, k2) return k1 < k2 end)
                             local AnyNodeHovered
-                            if  r.ImGui_IsKeyReleased(ctx, r.ImGui_Key_C()  ) or LBtnRel  then 
-
-                                DraggingLFOctrl = nil 
-                                Save_All_LFO_Info(Node) 
+                            if r.ImGui_IsKeyReleased(ctx, r.ImGui_Key_C()) or LBtnRel then
+                                DraggingLFOctrl = nil
+                                Save_All_LFO_Info(Node)
                             end
 
-                            All_Coord  = {X={};Y={}}
+                            All_Coord = { X = {}, Y = {} }
 
-                            if LFO.DeleteNode then 
+                            if LFO.DeleteNode then
                                 table.remove(Mc.Node, LFO.DeleteNode)
-                                Mc.NeedSendAllCoord = true 
-                                Save_All_LFO_Info(Node) 
-                                LFO.DeleteNode = nil 
+                                Mc.NeedSendAllCoord = true
+                                Save_All_LFO_Info(Node)
+                                LFO.DeleteNode = nil
                             end
 
 
-                            local PlayPosX = HdrPosL + r.gmem_read(108+i)/4 * LFO.Win.w
+                            local PlayPosX = HdrPosL + r.gmem_read(108 + i) / 4 * LFO.Win.w
 
-                            for i = 1 ,#Mc.Node, 1 do --- Rpt for every node   
-
-                                local last = math.max(i-1 , 1)
-                                local lastX, lastY = L+ (Node[last].x or 0) * LFO.DummyW, T+ (Node[last].y or Node[i].y)* LFO.DummyH
-                                local X , Y = L+ Node[i].x * LFO.DummyW , T+  Node[i].y * LFO.DummyH
-
-                                
+                            for i = 1, #Mc.Node, 1 do --- Rpt for every node
+                                local last = math.max(i - 1, 1)
+                                local lastX, lastY = L + (Node[last].x or 0) * LFO.DummyW,
+                                    T + (Node[last].y or Node[i].y) * LFO.DummyH
+                                local X, Y = L + Node[i].x * LFO.DummyW, T + Node[i].y * LFO.DummyH
 
 
-                                if AddNode(X -15/2 , Y -15 /2, i) then AnyNodeHovered = true end
-                                local CtrlX, CtrlY  = L+ (Node[i].ctrlX or (Node[last].x + Node[i].x) / 2)* LFO.DummyW, T+ (Node[i].ctrlY or (Node[last].y + Node[i].y) / 2)*LFO.DummyH
+
+
+                                if AddNode(X - 15 / 2, Y - 15 / 2, i) then AnyNodeHovered = true end
+                                local CtrlX, CtrlY = L + (Node[i].ctrlX or (Node[last].x + Node[i].x) / 2) * LFO.DummyW,
+                                    T + (Node[i].ctrlY or (Node[last].y + Node[i].y) / 2) * LFO.DummyH
 
 
                                 -- Control Node
@@ -2933,322 +2942,318 @@ function loop()
                                     local Sz = LFO.CtrlNodeSz
 
                                     ---- Draw Node
-                                    if not DraggingLFOctrl or DraggingLFOctrl == i  then
+                                    if not DraggingLFOctrl or DraggingLFOctrl == i then
                                         if not HoverNode and not DraggingNode then
-                                            r.ImGui_DrawList_AddBezierQuadratic(WDL, lastX, lastY, CtrlX, CtrlY, X, Y, 0xffffff44, 7)
+                                            r.ImGui_DrawList_AddBezierQuadratic(WDL, lastX, lastY, CtrlX, CtrlY, X, Y,
+                                                0xffffff44, 7)
                                             r.ImGui_DrawList_AddCircle(WDL, CtrlX, CtrlY, Sz, LineClr)
                                             --r.ImGui_DrawList_AddText(FDL, CtrlX, CtrlY, 0xffffffff, i)
                                         end
                                     end
 
                                     InvisiBtn(ctx, CtrlX - Sz / 2, CtrlY - Sz / 2, '##Ctrl Node' .. i, Sz)
-                                    if r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_C() , false )  or r.ImGui_IsItemActivated(ctx) then 
+                                    if r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_C(), false) or r.ImGui_IsItemActivated(ctx) then
                                         DraggingLFOctrl = i
                                     end
-                                    
+
                                     if r.ImGui_IsItemHovered(ctx) then
                                         r.ImGui_DrawList_AddCircle(WDL, CtrlX, CtrlY, Sz + 2, LineClr)
                                     end
                                 end
 
-                                -- decide which node is mouse closest to 
+                                -- decide which node is mouse closest to
                                 local Range = X - lastX
-                                if r.ImGui_IsMouseHoveringRect(ctx, lastX, Win_T, lastX + Range/2, Win_B) and not tweaking and not DraggingNode  then 
-                                    r.ImGui_DrawList_AddCircle(WDL, lastX, lastY, LFO.NodeSz+2, LineClr)
+                                if r.ImGui_IsMouseHoveringRect(ctx, lastX, Win_T, lastX + Range / 2, Win_B) and not tweaking and not DraggingNode then
+                                    r.ImGui_DrawList_AddCircle(WDL, lastX, lastY, LFO.NodeSz + 2, LineClr)
                                     MouseClosestNode = last
+                                elseif r.ImGui_IsMouseHoveringRect(ctx, lastX + Range / 2, Win_T, X, Win_B) and not tweaking and not DraggingNode then
+                                    r.ImGui_DrawList_AddCircle(WDL, X, Y, LFO.NodeSz + 2, LineClr)
 
-                                elseif r.ImGui_IsMouseHoveringRect(ctx, lastX + Range/2, Win_T, X, Win_B) and not tweaking and not DraggingNode  then 
-                                    r.ImGui_DrawList_AddCircle(WDL, X, Y, LFO.NodeSz+2, LineClr)
-
-                                    MouseClosestNode = i 
+                                    MouseClosestNode = i
                                 end
 
                                 --- changing control point
-                                if DraggingLFOctrl==i then
+                                if DraggingLFOctrl == i then
+                                    tweaking           = Macro
+                                    local Dx, Dy       = GetMouseDelta(0, r.ImGui_Key_C())
+                                    local Dx, Dy       = Dx / LFO.DummyW, Dy / LFO.DummyH
+                                    local CtrlX, CtrlY = Node[i].ctrlX or (Node[last].x + Node[i].x) / 2,
+                                        Node[i].ctrlY or (Node[last].y + Node[i].y) / 2
 
-                                    tweaking = Macro
-                                    local Dx, Dy =  GetMouseDelta(0, r.ImGui_Key_C())
-                                    local Dx , Dy = Dx / LFO.DummyW, Dy / LFO.DummyH
-                                    local CtrlX, CtrlY  =  Node[i].ctrlX or (Node[last].x + Node[i].x)/ 2,  Node[i].ctrlY or (Node[last].y + Node[i].y) / 2
+                                    Node[i].ctrlX      = SetMinMax(CtrlX + Dx, Node[last].x, Node[i].x)
+                                    Node[i].ctrlY      = SetMinMax(CtrlY + Dy, math.min(Node[last].y, Node[i].y),
+                                        math.max(Node[last].y, Node[i].y))
 
-                                    Node[i].ctrlX   = SetMinMax(CtrlX + Dx, Node[last].x , Node[i].x)
-                                    Node[i].ctrlY   = SetMinMax(CtrlY + Dy, math.min(Node[last].y , Node[i].y), math.max(Node[last].y , Node[i].y))
-
-                                    SaveLFO('Node'..i..'Ctrl X',  Node[i].ctrlX)
-                                    SaveLFO('Node'..i..'Ctrl Y',  Node[i].ctrlY)
+                                    SaveLFO('Node' .. i .. 'Ctrl X', Node[i].ctrlX)
+                                    SaveLFO('Node' .. i .. 'Ctrl Y', Node[i].ctrlY)
                                     Send_All_Coord()
-                                    
                                 end
 
 
 
 
 
-                                if (Mc.LFO_Gain or 1) ~=1 then 
-                                    local B = T+LFO.DummyH
-                                    local y = -Node[i].y+1
-                                    local Y = B-  y * LFO.DummyH * Mc.LFO_Gain
-                                    local lastY = B- (-(Node[last].y or Node[i].y)+1)* LFO.DummyH* Mc.LFO_Gain
-                                    local CtrlY = B- (-(Node[i].ctrlY or (Node[last].y + Node[i].y) / 2)+1) *LFO.DummyH * Mc.LFO_Gain
+                                if (Mc.LFO_Gain or 1) ~= 1 then
+                                    local B = T + LFO.DummyH
+                                    local y = -Node[i].y + 1
+                                    local Y = B - y * LFO.DummyH * Mc.LFO_Gain
+                                    local lastY = B - (-(Node[last].y or Node[i].y) + 1) * LFO.DummyH * Mc.LFO_Gain
+                                    local CtrlY = B -
+                                        (-(Node[i].ctrlY or (Node[last].y + Node[i].y) / 2) + 1) * LFO.DummyH *
+                                        Mc.LFO_Gain
                                     local PtsX = {}
                                     local PtsY = {}
-                                    local PtsX, PtsY =  Curve_3pt_Bezier(lastX,lastY,CtrlX,CtrlY,X,Y)
+                                    local PtsX, PtsY = Curve_3pt_Bezier(lastX, lastY, CtrlX, CtrlY, X, Y)
 
-                                    for i= 1, #PtsX, 2 do  
-                                        if i > 1 then      -- >1 because you need two points to draw a line
-                                            r.ImGui_DrawList_AddLine(WDL, PtsX[i-1] ,PtsY[i-1], PtsX[i],PtsY[i], 0xffffffff)
+                                    for i = 1, #PtsX, 2 do
+                                        if i > 1 then -- >1 because you need two points to draw a line
+                                            r.ImGui_DrawList_AddLine(WDL, PtsX[i - 1], PtsY[i - 1], PtsX[i], PtsY[i],
+                                                0xffffffff)
                                         end
                                     end
                                 end
-                                
+
                                 PtsX = {}
                                 PtsY = {}
 
-                                PtsX, PtsY =  Curve_3pt_Bezier(lastX,lastY,CtrlX,CtrlY,X,Y)
+                                PtsX, PtsY = Curve_3pt_Bezier(lastX, lastY, CtrlX, CtrlY, X, Y)
 
-                                if Wheel_V~=0 then Sqr = ( Sqr or 0 ) + Wheel_V / 100 end 
+                                if Wheel_V ~= 0 then Sqr = (Sqr or 0) + Wheel_V / 100 end
 
-                            
+
                                 --r.ImGui_DrawList_AddLine(FDL, p.x, p.y, 0xffffffff)
 
 
 
                                 local N = i
-                                local CurrentPlayPos 
-                                for i, v in ipairs(PtsX) do  
-                                    
-                                    if i > 1 then      -- >1 because you need two points to draw a line
-                                        local n = math.min (i+1, #PtsX )
-                                        
-                                        if PlayPosX > PtsX[i-1] and PlayPosX < PtsX[i] then 
+                                local CurrentPlayPos
+                                for i, v in ipairs(PtsX) do
+                                    if i > 1 then -- >1 because you need two points to draw a line
+                                        local n = math.min(i + 1, #PtsX)
 
-                                            CurrentPlayPos = i 
-
+                                        if PlayPosX > PtsX[i - 1] and PlayPosX < PtsX[i] then
+                                            CurrentPlayPos = i
                                         end
-                                        r.ImGui_DrawList_AddLine(WDL, PtsX[i-1] ,PtsY[i-1], PtsX[i],PtsY[i], 0xffffffff)
-                                        
+                                        r.ImGui_DrawList_AddLine(WDL, PtsX[i - 1], PtsY[i - 1], PtsX[i], PtsY[i],
+                                            0xffffffff)
                                     end
                                     ----- things below don't need >1 because jsfx needs all points to draw lines
-                                    
-                                   
+
+
 
                                     --- normalize values
                                     local NormX = (PtsX[i] - HdrPosL) / LFO.Win.w
                                     local NormY = (Win_B - PtsY[i]) / (LFO.DummyH) -- i think 3 is the window padding
-        
+
 
 
                                     --[[ r.gmem_write(4, 15) -- mode 15 tells jsfx to retrieve all coordinates
                                     r.gmem_write(5, Macro) ]]
-                                    --[[ 
+                                    --[[
                                     r.gmem_write(1000+i*N, NormX) -- gmem 1000 ~ 1999 = X coordinates
                                     r.gmem_write(2000+i*N, NormY) -- gmem 2000 ~ 2999 = Y coordinates ]]
-                                    table.insert(All_Coord.X,  NormX or 0)
-                                    table.insert(All_Coord.Y,  NormY or 0)
-
-                                   
-
-
-
+                                    table.insert(All_Coord.X, NormX or 0)
+                                    table.insert(All_Coord.Y, NormY or 0)
                                 end
 
-                                function Send_All_Coord ()
-                                    for i  , v in ipairs(All_Coord.X) do 
+                                function Send_All_Coord()
+                                    for i, v in ipairs(All_Coord.X) do
                                         r.gmem_write(4, 15) -- mode 15 tells jsfx to retrieve all coordinates
                                         r.gmem_write(5, Macro)
-                                        r.gmem_write(6, #Mc.Node*11)
-                                        r.gmem_write(1000+i, v)
-                                        r.gmem_write(2000+i, All_Coord.Y[i])
+                                        r.gmem_write(6, #Mc.Node * 11)
+                                        r.gmem_write(1000 + i, v)
+                                        r.gmem_write(2000 + i, All_Coord.Y[i])
                                     end
                                 end
 
-
-
-
-                                 if CurrentPlayPos and (Mc.LFO_spd or 1) >=2 then 
-                                    for i= 1, CurrentPlayPos , 1  do  
-                                        local pos = CurrentPlayPos-1
-                                        local L = math.max(pos-i, 1)
-                                        --if PtsX[pos] > PtsX[i] -30  then  -- if playhead is 60 pixels right to current point 
-                                            r.ImGui_DrawList_AddLine(FDL, PtsX[L+1] ,PtsY[L+1], PtsX[L],PtsY[L], 0xffffff88, 7 - 7*(i*0.1) )
-                                       -- end
+                                if CurrentPlayPos and (Mc.LFO_spd or 1) >= 2 then
+                                    for i = 1, CurrentPlayPos, 1 do
+                                        local pos = CurrentPlayPos - 1
+                                        local L = math.max(pos - i, 1)
+                                        --if PtsX[pos] > PtsX[i] -30  then  -- if playhead is 60 pixels right to current point
+                                        r.ImGui_DrawList_AddLine(FDL, PtsX[L + 1], PtsY[L + 1], PtsX[L], PtsY[L],
+                                            0xffffff88, 7 - 7 * (i * 0.1))
+                                        -- end
                                         --r.ImGui_DrawList_AddText(FDL, PtsX[i] ,PtsY[i], 0xffffffff, i)
 
 
-                                        -- calculate how far X and last x 
-                                        local Ly , Lx    
+                                        -- calculate how far X and last x
+                                        local Ly, Lx
 
                                         testTB = {}
 
-                                        for i= 0 , (PlayPosX - PtsX[pos] ) , (PlayPosX - PtsX[pos]) / 4 do 
-                                            local n = math.min(pos+1  , #PtsX)
-                                            local x2 =  PtsX[pos] +  i 
-                                            local y2 =  PtsY[pos] + (PtsY[CurrentPlayPos] - PtsY[pos]) *  ( i/  (PtsX[n] -PtsX[pos]) )
-                                            
-                                            r.ImGui_DrawList_AddLine(FDL, Lx or x2 , Ly or y2 , x2, y2, Change_Clr_A( 0xffffff00, (i /(PlayPosX - PtsX[pos])) * 0.3  ), 7     )
-                                            Ly = y2 
+                                        for i = 0, (PlayPosX - PtsX[pos]), (PlayPosX - PtsX[pos]) / 4 do
+                                            local n = math.min(pos + 1, #PtsX)
+                                            local x2 = PtsX[pos] + i
+                                            local y2 = PtsY[pos] +
+                                                (PtsY[CurrentPlayPos] - PtsY[pos]) * (i / (PtsX[n] - PtsX[pos]))
+
+                                            r.ImGui_DrawList_AddLine(FDL, Lx or x2, Ly or y2, x2, y2,
+                                                Change_Clr_A(0xffffff00, (i / (PlayPosX - PtsX[pos])) * 0.3), 7)
+                                            Ly = y2
                                             Lx = x2
-                                            
-                                            table.insert(testTB ,  (i /(PlayPosX - PtsX[pos])))
+
+                                            table.insert(testTB, (i / (PlayPosX - PtsX[pos])))
                                         end
                                     end
-                                end 
+                                end
 
 
 
-                                r.gmem_write(6, #Node*11)
+                                r.gmem_write(6, #Node * 11)
 
                                 --r.ImGui_DrawList_AddBezierQuadratic(FDL, lastX, lastY, CtrlX, CtrlY, v, Y, 0xffffffff, 3)
                             end
 
-                            if (Mc.LFO_spd or 1) < 2 then 
-                                DrawLFOvalueTrail (Mc , PlayPosX,  Win_B - MOD * LFO.DummyH , Macro )
+                            if (Mc.LFO_spd or 1) < 2 then
+                                DrawLFOvalueTrail(Mc, PlayPosX, Win_B - MOD * LFO.DummyH, Macro)
                             end
 
 
-                            for i, v in ipairs(All_Coord.X) do 
-                                r.gmem_write(1000+i, v)
-                                r.gmem_write(2000+i, All_Coord.Y[i])
-
+                            for i, v in ipairs(All_Coord.X) do
+                                r.gmem_write(1000 + i, v)
+                                r.gmem_write(2000 + i, All_Coord.Y[i])
                             end
 
 
-                            if DraggingLFOctrl then 
-
-                                HideCursorTillMouseUp(nil, r.ImGui_Key_C() )
+                            if DraggingLFOctrl then
+                                HideCursorTillMouseUp(nil, r.ImGui_Key_C())
                                 HideCursorTillMouseUp(0)
-                                
                             end
-                            
+
 
                             if not AnyNodeHovered then HoverNode = nil end
 
 
                             --r.ImGui_DrawList_PathStroke(FDL, 0xffffffff, nil, 2)
 
-                            --- Draw Playhead 
+                            --- Draw Playhead
 
-                            r.ImGui_DrawList_AddLine(WDL ,PlayPosX , Win_T,PlayPosX, Win_B , 0xffffff99, 4 )
-                            r.ImGui_DrawList_AddCircleFilled(WDL,PlayPosX, Win_B - MOD * LFO.DummyH , 5, 0xffffffcc)
+                            r.ImGui_DrawList_AddLine(WDL, PlayPosX, Win_T, PlayPosX, Win_B, 0xffffff99, 4)
+                            r.ImGui_DrawList_AddCircleFilled(WDL, PlayPosX, Win_B - MOD * LFO.DummyH, 5, 0xffffffcc)
 
-                            --- Draw animated Trail for modulated value 
+                            --- Draw animated Trail for modulated value
                             --[[ Mc.LFO_Trail = Mc.LFO_Trail or {}
                             table.insert(Mc.LFO_Trail , Win_B - MOD * LFO.DummyH)
-                            if # Mc.LFO_Trail > 100 then table.remove(Mc.LFO_Trail, 1) end 
-                            for i, v in ipairs( Mc.LFO_Trail) do 
-                                
+                            if # Mc.LFO_Trail > 100 then table.remove(Mc.LFO_Trail, 1) end
+                            for i, v in ipairs( Mc.LFO_Trail) do
+
                             end ]]
 
-                            
-                            if Mc.NeedSendAllCoord then 
+
+                            if Mc.NeedSendAllCoord then
                                 Send_All_Coord()
                                 Mc.NeedSendAllCoord = nil
                             end
 
-                            -- Draw Grid 
+                            -- Draw Grid
 
-                            local function DrawGridLine_V (division)
+                            local function DrawGridLine_V(division)
                                 local Pad_L = 5
-                                for i= 0, division, 1 do 
-                                    local W = (X_range/division)
+                                for i = 0, division, 1 do
+                                    local W = (X_range / division)
                                     local R = HdrPosL + X_range
-                                    local X = Pad_L +HdrPosL +  W * i
-                                    r.ImGui_DrawList_AddLine(WDL ,X, Win_T,X, Win_B , 0xffffff55, 2 )
+                                    local X = Pad_L + HdrPosL + W * i
+                                    r.ImGui_DrawList_AddLine(WDL, X, Win_T, X, Win_B, 0xffffff55, 2)
                                 end
                             end
-                            DrawGridLine_V(Mc.LFO_leng or LFO.Def.Len )
+                            DrawGridLine_V(Mc.LFO_leng or LFO.Def.Len)
 
 
-                            r.ImGui_SetCursorPos(ctx, 10,  LFO.Win.h + 55)
+                            r.ImGui_SetCursorPos(ctx, 10, LFO.Win.h + 55)
                             r.ImGui_AlignTextToFramePadding(ctx)
-                            r.ImGui_Text(ctx,'Speed:') SL()
+                            r.ImGui_Text(ctx, 'Speed:')
+                            SL()
                             r.ImGui_SetNextItemWidth(ctx, 50)
-                            local rv, V =  r.ImGui_DragDouble(ctx, '##Speed', Mc.LFO_spd or 1, 0.05, 0.125, 128, 'x %.3f' )
-                            if r.ImGui_IsItemActive(ctx) then 
-                                ChangeLFO(12, Mc.LFO_spd or 1, 9, 'LFO Speed' )
-                                tweaking = Macro 
+                            local rv, V = r.ImGui_DragDouble(ctx, '##Speed', Mc.LFO_spd or 1, 0.05, 0.125, 128, 'x %.3f')
+                            if r.ImGui_IsItemActive(ctx) then
+                                ChangeLFO(12, Mc.LFO_spd or 1, 9, 'LFO Speed')
+                                tweaking = Macro
                                 Mc.LFO_spd = V
                             end
-                            if r.ImGui_IsItemClicked(ctx,1 ) and Mods ==Ctrl then 
-                                r.ImGui_OpenPopup(ctx,'##LFO Speed menu' .. Macro)
+                            if r.ImGui_IsItemClicked(ctx, 1) and Mods == Ctrl then
+                                r.ImGui_OpenPopup(ctx, '##LFO Speed menu' .. Macro)
                             end
                             if r.ImGui_BeginPopup(ctx, '##LFO Speed menu' .. Macro) then
                                 tweaking = Macro
                                 if r.ImGui_Selectable(ctx, 'Add Parameter to Envelope', false) then
-                                    AutomateModPrm (Macro,'LFO Speed', 17, 'LFO '..Macro..' Speed')
+                                    AutomateModPrm(Macro, 'LFO Speed', 17, 'LFO ' .. Macro .. ' Speed')
                                     r.TrackList_AdjustWindows(false)
-                                    r.UpdateArrange() 
+                                    r.UpdateArrange()
                                 end
 
                                 r.ImGui_EndPopup(ctx)
                             end
-                            if Mods == Alt and r.ImGui_IsItemActivated(ctx) then Mc.LFO_spd = 1 end 
-                            if r.ImGui_IsItemHovered(ctx) then 
-                                if r.ImGui_IsKeyPressed(ctx,r.ImGui_Key_DownArrow(), false) then 
-                                    Mc.LFO_spd = (Mc.LFO_spd or 1 )/2 
-                                    ChangeLFO(12, Mc.LFO_spd or 1, 9, 'LFO Speed' )
-                                elseif r.ImGui_IsKeyPressed(ctx,r.ImGui_Key_UpArrow(), false) then 
+                            if Mods == Alt and r.ImGui_IsItemActivated(ctx) then Mc.LFO_spd = 1 end
+                            if r.ImGui_IsItemHovered(ctx) then
+                                if r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_DownArrow(), false) then
+                                    Mc.LFO_spd = (Mc.LFO_spd or 1) / 2
+                                    ChangeLFO(12, Mc.LFO_spd or 1, 9, 'LFO Speed')
+                                elseif r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_UpArrow(), false) then
                                     Mc.LFO_spd = (Mc.LFO_spd or 1) * 2
-                                    ChangeLFO(12, Mc.LFO_spd or 1, 9, 'LFO Speed' )
+                                    ChangeLFO(12, Mc.LFO_spd or 1, 9, 'LFO Speed')
                                 end
                             end
                             SL(nil, 30)
 
-                            
+
                             ---- Add Length slider
-                            r.ImGui_Text(ctx, 'Length:') SL()
+                            r.ImGui_Text(ctx, 'Length:')
+                            SL()
                             r.ImGui_SetNextItemWidth(ctx, 80)
                             local LengthBefore = Mc.LFO_leng
-                            rv, Mc.LFO_leng = r.ImGui_SliderInt(ctx, '##' .. 'Macro' .. i .. 'LFO Length', Mc.LFO_leng or LFO.Def.Len, 1, 8)
-                            if r.ImGui_IsItemActive(ctx ) then 
-                                tweaking=Macro  
-                                ChangeLFO(13, Mc.LFO_leng or LFO.Def.Len, 9, 'LFO Length' )
-                            end 
-                            if r.ImGui_IsItemEdited(ctx) then 
-                                local Change =   Mc.LFO_leng - LengthBefore 
+                            rv, Mc.LFO_leng = r.ImGui_SliderInt(ctx, '##' .. 'Macro' .. i .. 'LFO Length',
+                                Mc.LFO_leng or LFO.Def.Len, 1, 8)
+                            if r.ImGui_IsItemActive(ctx) then
+                                tweaking = Macro
+                                ChangeLFO(13, Mc.LFO_leng or LFO.Def.Len, 9, 'LFO Length')
+                            end
+                            if r.ImGui_IsItemEdited(ctx) then
+                                local Change = Mc.LFO_leng - LengthBefore
 
-                                for i, v in ipairs( Node) do 
-                                    Node[i].x =  Node[i].x / ((LengthBefore+Change) / LengthBefore )
-                                    if Node[i].ctrlX then 
-                                        Node[i].ctrlX = Node[i].ctrlX / ((LengthBefore+Change) / LengthBefore )
+                                for i, v in ipairs(Node) do
+                                    Node[i].x = Node[i].x / ((LengthBefore + Change) / LengthBefore)
+                                    if Node[i].ctrlX then
+                                        Node[i].ctrlX = Node[i].ctrlX / ((LengthBefore + Change) / LengthBefore)
                                     end
                                 end
                                 LengthBefore = Mc.LFO_leng
-                            end 
+                            end
 
 
-                            ------ Add LFO Gain  
+                            ------ Add LFO Gain
                             SL()
                             r.ImGui_Text(ctx, 'Gain')
                             SL()
                             r.ImGui_SetNextItemWidth(ctx, 80)
-                            local ShownV =math.floor( ( Mc.LFO_Gain or 0)* 100)
+                            local ShownV = math.floor((Mc.LFO_Gain or 0) * 100)
 
                             -- check if prm has been assigned automation
-                            local  AutoPrmIdx = tablefind(Trk[TrkID].AutoPrms, 'Mod'.. Macro..'LFO Gain')  
-                            
-                            
-                            rv, Mc.LFO_Gain = r.ImGui_DragDouble(ctx, '##' .. 'Macro' .. i .. 'LFO Gain', Mc.LFO_Gain or 1 , 0.01, 0 , 1, ShownV .. '%%')
-                            if r.ImGui_IsItemActive(ctx ) then 
-                                tweaking=Macro  
-                                ChangeLFO(14, Mc.LFO_Gain, 9, 'LFO Gain' )
-                                if AutoPrmIdx then 
-                                    r.TrackFX_SetParamNormalized(LT_Track, 0 , 15+ AutoPrmIdx , Mc.LFO_Gain)
+                            local AutoPrmIdx = tablefind(Trk[TrkID].AutoPrms, 'Mod' .. Macro .. 'LFO Gain')
+
+
+                            rv, Mc.LFO_Gain = r.ImGui_DragDouble(ctx, '##' .. 'Macro' .. i .. 'LFO Gain',
+                                Mc.LFO_Gain or 1, 0.01, 0, 1, ShownV .. '%%')
+                            if r.ImGui_IsItemActive(ctx) then
+                                tweaking = Macro
+                                ChangeLFO(14, Mc.LFO_Gain, 9, 'LFO Gain')
+                                if AutoPrmIdx then
+                                    r.TrackFX_SetParamNormalized(LT_Track, 0, 15 + AutoPrmIdx, Mc.LFO_Gain)
                                 end
-                            else 
-                                if AutoPrmIdx then 
-                                    Mc.LFO_Gain = r.TrackFX_GetParamNormalized(LT_Track, 0, 15+ AutoPrmIdx)
+                            else
+                                if AutoPrmIdx then
+                                    Mc.LFO_Gain = r.TrackFX_GetParamNormalized(LT_Track, 0, 15 + AutoPrmIdx)
                                 end
                             end
-                            if r.ImGui_IsItemClicked(ctx,1 ) and Mods ==Ctrl then 
-                                r.ImGui_OpenPopup(ctx,'##LFO Gain menu' .. Macro)
+                            if r.ImGui_IsItemClicked(ctx, 1) and Mods == Ctrl then
+                                r.ImGui_OpenPopup(ctx, '##LFO Gain menu' .. Macro)
                             end
                             if r.ImGui_BeginPopup(ctx, '##LFO Gain menu' .. Macro) then
                                 tweaking = Macro
                                 if r.ImGui_Selectable(ctx, 'Add Parameter to Envelope', false) then
-                                    AutomateModPrm (Macro,'LFO Gain', 16, 'LFO '..Macro..' Gain')
+                                    AutomateModPrm(Macro, 'LFO Gain', 16, 'LFO ' .. Macro .. ' Gain')
                                     r.TrackList_AdjustWindows(false)
-                                    r.UpdateArrange() 
+                                    r.UpdateArrange()
                                 end
 
                                 r.ImGui_EndPopup(ctx)
@@ -3256,166 +3261,164 @@ function loop()
 
 
 
-                            if Mc.Changing_Rel_Node then 
+                            if Mc.Changing_Rel_Node then
                                 Mc.Rel_Node = Mc.Changing_Rel_Node
-                                ChangeLFO( 20 , Mc.Rel_Node , nil, 'LFO_Rel_Node')
-                                Mc.Changing_Rel_Node = nil 
+                                ChangeLFO(20, Mc.Rel_Node, nil, 'LFO_Rel_Node')
+                                Mc.Changing_Rel_Node = nil
                             end
 
 
 
-                            if  r.ImGui_IsWindowHovered(ctx,r.ImGui_HoveredFlags_RootAndChildWindows()) then 
-                                LFO.WinHovered = Macro  -- this one doesn't get cleared after unhovering, to inform script which one to stay open
-                                LFO.HvringWin= Macro      
-                            else LFO.HvringWin = nil 
-                                LFO.DontOpenNextFrame = true   -- it's needed so the open_LFO_Win function doesn't get called twice when user 'unhover' the lfo window
+                            if r.ImGui_IsWindowHovered(ctx, r.ImGui_HoveredFlags_RootAndChildWindows()) then
+                                LFO.WinHovered =
+                                    Macro -- this one doesn't get cleared after unhovering, to inform script which one to stay open
+                                LFO.HvringWin = Macro
+                            else
+                                LFO.HvringWin = nil
+                                LFO.DontOpenNextFrame = true -- it's needed so the open_LFO_Win function doesn't get called twice when user 'unhover' the lfo window
                             end
-                            
-                            if r.ImGui_IsWindowAppearing(ctx) then 
-                                Save_All_LFO_Info(Node) 
+
+                            if r.ImGui_IsWindowAppearing(ctx) then
+                                Save_All_LFO_Info(Node)
                             end
-                            if r.ImGui_IsWindowAppearing(ctx) then 
+                            if r.ImGui_IsWindowAppearing(ctx) then
                                 Send_All_Coord()
                             end
                             r.ImGui_End(ctx)
                         end
 
 
-                        if LFO.OpenShapeSelect == Macro then 
-
-                            r.ImGui_SetNextWindowPos(ctx, L+LFO.DummyW + 30  ,T-LFO.DummyH - 200)
+                        if LFO.OpenShapeSelect == Macro then
+                            r.ImGui_SetNextWindowPos(ctx, L + LFO.DummyW + 30, T - LFO.DummyH - 200)
                             ShapeFilter = r.ImGui_CreateTextFilter(Shape_Filter_Txt)
-                            r.ImGui_SetNextWindowSizeConstraints( ctx, 220, 150, 240, 700)
-                            if r.ImGui_Begin(ctx, 'Shape Selection Popup',true,  r.ImGui_WindowFlags_NoTitleBar()|r.ImGui_WindowFlags_AlwaysAutoResize()) then 
+                            r.ImGui_SetNextWindowSizeConstraints(ctx, 220, 150, 240, 700)
+                            if r.ImGui_Begin(ctx, 'Shape Selection Popup', true, r.ImGui_WindowFlags_NoTitleBar()|r.ImGui_WindowFlags_AlwaysAutoResize()) then
                                 local W, H = 150, 75
                                 local function DrawShapesInSelector(Shapes)
                                     local AnyShapeHovered
-                                    for i,v in pairs(Shapes) do 
+                                    for i, v in pairs(Shapes) do
                                         --InvisiBtn(ctx, nil,nil, 'Shape'..i,  W, H)
 
                                         if r.ImGui_TextFilter_PassFilter(ShapeFilter, v.Name) then
                                             r.ImGui_Text(ctx, v.Name or i)
-                                           
+
                                             --reaper.ImGui_SetCursorPosX( ctx, - 15 )
                                             local L, T = r.ImGui_GetItemRectMin(ctx)
-                                            if r.ImGui_IsMouseHoveringRect( ctx, L,T, L+ 200, T + 10 ) then 
-                                                SL( W-8)
-    
-                                                if TrashIcon(8, 'delete'..(v.Name or i), 0xffffff00) then 
-                                                    r.ImGui_OpenPopup(ctx, 'Delete shape prompt'..i)
-                                                    r.ImGui_SetNextWindowPos(ctx,L, T)
+                                            if r.ImGui_IsMouseHoveringRect(ctx, L, T, L + 200, T + 10) then
+                                                SL(W - 8)
+
+                                                if TrashIcon(8, 'delete' .. (v.Name or i), 0xffffff00) then
+                                                    r.ImGui_OpenPopup(ctx, 'Delete shape prompt' .. i)
+                                                    r.ImGui_SetNextWindowPos(ctx, L, T)
                                                 end
                                             end
-                                            
-                                            if r.ImGui_Button(ctx,'##'..(v.Name or i)..i, W, H ) then 
-                                                Mc.Node = v 
+
+                                            if r.ImGui_Button(ctx, '##' .. (v.Name or i) .. i, W, H) then
+                                                Mc.Node = v
                                                 LFO.NewShapeChosen = v
                                             end
                                             if r.ImGui_IsItemHovered(ctx) then
                                                 Mc.Node = v
-                                                AnyShapeHovered = true 
-                                                LFO.AnyShapeHovered = true 
+                                                AnyShapeHovered = true
+                                                LFO.AnyShapeHovered = true
                                                 Send_All_Coord()
                                             end
                                             local L, T = r.ImGui_GetItemRectMin(ctx)
                                             local w, h = r.ImGui_GetItemRectSize(ctx)
-                                            r.ImGui_DrawList_AddRectFilled(WDL, L,T,L+w, T+h , 0xffffff33)
-                                            r.ImGui_DrawList_AddRect(WDL, L,T,L+w, T+h , 0xffffff66)
-    
-                                            DrawShape (v , L,  w, h, T , 0xffffffaa)
+                                            r.ImGui_DrawList_AddRectFilled(WDL, L, T, L + w, T + h, 0xffffff33)
+                                            r.ImGui_DrawList_AddRect(WDL, L, T, L + w, T + h, 0xffffff66)
+
+                                            DrawShape(v, L, w, h, T, 0xffffffaa)
                                         end
-                                        if r.ImGui_BeginPopupModal(ctx, 'Delete shape prompt'..i, true ,  r.ImGui_WindowFlags_NoTitleBar()|r.ImGui_WindowFlags_NoResize()|r.ImGui_WindowFlags_AlwaysAutoResize()) then 
+                                        if r.ImGui_BeginPopupModal(ctx, 'Delete shape prompt' .. i, true, r.ImGui_WindowFlags_NoTitleBar()|r.ImGui_WindowFlags_NoResize()|r.ImGui_WindowFlags_AlwaysAutoResize()) then
                                             r.ImGui_Text(ctx, 'Confirm deleting this shape:')
-                                            if  r.ImGui_Button(ctx, 'yes') or r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_Y()) or r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_Enter()) then 
-                                               LFO.DeleteShape = i 
-                                               r.ImGui_CloseCurrentPopup(ctx)
-    
+                                            if r.ImGui_Button(ctx, 'yes') or r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_Y()) or r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_Enter()) then
+                                                LFO.DeleteShape = i
+                                                r.ImGui_CloseCurrentPopup(ctx)
                                             end
                                             SL()
-                                            if r.ImGui_Button(ctx, 'No') or  r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_N()) or r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_Escape()) then 
+                                            if r.ImGui_Button(ctx, 'No') or r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_N()) or r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_Escape()) then
                                                 r.ImGui_CloseCurrentPopup(ctx)
                                             end
                                             r.ImGui_EndPopup(ctx)
                                         end
                                     end
-                                    if LFO.AnyShapeHovered  then  -- if any shape was hovered
-                                        if not AnyShapeHovered then   -- if 'unhovered'
-                                            if  LFO.NewShapeChosen then 
+                                    if LFO.AnyShapeHovered then     -- if any shape was hovered
+                                        if not AnyShapeHovered then -- if 'unhovered'
+                                            if LFO.NewShapeChosen then
                                                 local V = LFO.NewShapeChosen
-                                                Mc.Node = V   ---keep newly selected shape
+                                                Mc.Node = V                     ---keep newly selected shape
                                             else
-                                                Mc.Node = LFO.NodeBeforePreview     -- restore original shape
-                                                NeedSendAllGmemLater = Macro 
+                                                Mc.Node = LFO.NodeBeforePreview -- restore original shape
+                                                NeedSendAllGmemLater = Macro
                                             end
                                             LFO.NodeBeforePreview = Mc.Node
-                                            LFO.AnyShapeHovered = nil 
-                                            LFO.NewShapeChosen = nil 
+                                            LFO.AnyShapeHovered = nil
+                                            LFO.NewShapeChosen = nil
                                         end
-                                    end 
+                                    end
 
-                                    
+
                                     return AnyShapeHovered
                                 end
 
-                                if NeedSendAllGmemLater == Macro then 
+                                if NeedSendAllGmemLater == Macro then
                                     timer = (timer or 0) + 1
-                                    if timer == 2 then   
+                                    if timer == 2 then
                                         Send_All_Coord()
-                                        NeedSendAllGmemLater = nil 
+                                        NeedSendAllGmemLater = nil
                                         timer = nil
                                     end
                                 end
 
-                                local function  Global_Shapes()
-                                    
-                                    if r.ImGui_IsWindowAppearing(ctx) then  
+                                local function Global_Shapes()
+                                    if r.ImGui_IsWindowAppearing(ctx) then
                                         LFO.NodeBeforePreview = Mc.Node
                                     end
-                                    
-                                    Shapes =  {}
-    
-    
-    
+
+                                    Shapes = {}
+
+
+
                                     local F = scandir(ConcatPath(CurrentDirectory, 'src', 'LFO Shapes'))
-                                    
-    
-                                    for i, v in ipairs(F ) do 
-    
+
+
+                                    for i, v in ipairs(F) do
                                         local Shape = Get_LFO_Shape_From_File(v)
-                                        if Shape then 
-                                            Shape.Name = tostring(v):sub(0, -5) 
-                                            table.insert( Shapes, Shape )
-                                        end 
+                                        if Shape then
+                                            Shape.Name = tostring(v):sub(0, -5)
+                                            table.insert(Shapes, Shape)
+                                        end
                                     end
-    
-    
+
+
                                     if LFO.DeleteShape then
-                                        os.remove(ConcatPath(CurrentDirectory, 'src', 'LFO Shapes', Shapes[LFO.DeleteShape].Name..'.ini' ))
+                                        os.remove(ConcatPath(CurrentDirectory, 'src', 'LFO Shapes',
+                                            Shapes[LFO.DeleteShape].Name .. '.ini'))
                                         table.remove(Shapes, LFO.DeleteShape)
-                                        LFO.DeleteShape = nil 
+                                        LFO.DeleteShape = nil
                                     end
-    
-                                    if r.ImGui_TextFilter_Draw(ShapeFilter, ctx, '##PrmFilterTxt', -1 ) then
+
+                                    if r.ImGui_TextFilter_Draw(ShapeFilter, ctx, '##PrmFilterTxt', -1) then
                                         Shape_Filter_Txt = r.ImGui_TextFilter_Get(ShapeFilter)
                                         r.ImGui_TextFilter_Set(ShapeFilter, Shape_Filter_Txt)
                                     end
-    
-    
-    
+
+
+
 
                                     AnyShapeHovered = DrawShapesInSelector(Shapes)
-    
-                                    
-    
-                                    
-                                  
-    
-    
-                                   
-    
-    
-                                    if r.ImGui_IsWindowFocused( ctx) and r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_Escape()) then 
-                                        
+
+
+
+
+
+
+
+
+
+
+                                    if r.ImGui_IsWindowFocused(ctx) and r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_Escape()) then
                                         r.ImGui_CloseCurrentPopup(ctx)
                                         LFO.OpenShapeSelect = nil
                                     end
@@ -3423,141 +3426,162 @@ function loop()
 
 
                                 local function Save_Shape_To_Track()
-                                    local HowManySavedShapes = GetTrkSavedInfo ('LFO Saved Shape Count')
+                                    local HowManySavedShapes = GetTrkSavedInfo('LFO Saved Shape Count')
 
-                                    if HowManySavedShapes then 
-                                        r.GetSetMediaTrackInfo_String(LT_Track,  'P_EXT: LFO Saved Shape Count', (HowManySavedShapes or 0)+1, true )
-                                    else r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: LFO Saved Shape Count', 1, true )
+                                    if HowManySavedShapes then
+                                        r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: LFO Saved Shape Count',
+                                            (HowManySavedShapes or 0) + 1, true)
+                                    else
+                                        r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: LFO Saved Shape Count', 1, true)
                                     end
-                                    local I  = (HowManySavedShapes or 0 )+1
-                                    for i, v in ipairs(Mc.Node) do 
-                                        if i ==1 then 
-                                            r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Shape'..I..'LFO Node Count = ', #Mc.Node, true)
+                                    local I = (HowManySavedShapes or 0) + 1
+                                    for i, v in ipairs(Mc.Node) do
+                                        if i == 1 then
+                                            r.GetSetMediaTrackInfo_String(LT_Track,
+                                                'P_EXT: Shape' .. I .. 'LFO Node Count = ', #Mc.Node, true)
                                         end
-                                        r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Shape'..I..'Node '..i.. 'x = ', v.x, true)
-                                        r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Shape'..I..'Node '..i.. 'y = ', v.y, true)
+                                        r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Shape' .. I ..
+                                            'Node ' .. i .. 'x = ', v.x, true)
+                                        r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Shape' .. I ..
+                                            'Node ' .. i .. 'y = ', v.y, true)
 
-                                        r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Shape'..I..'Node '..i.. '.ctrlX = ' , v.ctrlX or '',true)
-                                        r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Shape'..I..'Node '..i.. '.ctrlY = ' , v.ctrlY or '',true)
-
+                                        r.GetSetMediaTrackInfo_String(LT_Track,
+                                            'P_EXT: Shape' .. I .. 'Node ' .. i .. '.ctrlX = ', v.ctrlX or '', true)
+                                        r.GetSetMediaTrackInfo_String(LT_Track,
+                                            'P_EXT: Shape' .. I .. 'Node ' .. i .. '.ctrlY = ', v.ctrlY or '', true)
                                     end
-                                   
                                 end
                                 local function Save_Shape_To_Project()
+                                    local HowManySavedShapes = getProjSavedInfo('LFO Saved Shape Count')
 
-                                    local HowManySavedShapes = getProjSavedInfo('LFO Saved Shape Count' )
+                                    r.SetProjExtState(0, 'FX Devices', 'LFO Saved Shape Count',
+                                        (HowManySavedShapes or 0) + 1)
 
-                                    r.SetProjExtState(0, 'FX Devices', 'LFO Saved Shape Count' , (HowManySavedShapes or 0)+1 )
 
-
-                                    local I  = (HowManySavedShapes or 0 )+1
-                                    for i, v in ipairs(Mc.Node) do 
-                                        if i ==1 then 
-                                            r.SetProjExtState(0, 'FX Devices', 'LFO Shape'..I..'Node Count = ' ,  #Mc.Node )
+                                    local I = (HowManySavedShapes or 0) + 1
+                                    for i, v in ipairs(Mc.Node) do
+                                        if i == 1 then
+                                            r.SetProjExtState(0, 'FX Devices', 'LFO Shape' .. I .. 'Node Count = ',
+                                                #Mc.Node)
                                         end
-                                        r.SetProjExtState(0, 'FX Devices', 'LFO Shape'..I..'Node '..i.. 'x = ', v.x)
-                                        r.SetProjExtState(0, 'FX Devices', 'LFO Shape'..I..'Node '..i.. 'y = ', v.y)
+                                        r.SetProjExtState(0, 'FX Devices', 'LFO Shape' .. I .. 'Node ' .. i .. 'x = ',
+                                            v.x)
+                                        r.SetProjExtState(0, 'FX Devices', 'LFO Shape' .. I .. 'Node ' .. i .. 'y = ',
+                                            v.y)
 
-                                        r.SetProjExtState(0, 'FX Devices', 'LFO Shape'..I..'Node '..i.. '.ctrlX = ' , v.ctrlX or '' )
-                                        r.SetProjExtState(0, 'FX Devices', 'LFO Shape'..I..'Node '..i.. '.ctrlY = ' , v.ctrlY or '' )
+                                        r.SetProjExtState(0, 'FX Devices', 'LFO Shape' .. I .. 'Node ' .. i ..
+                                            '.ctrlX = ', v.ctrlX or '')
+                                        r.SetProjExtState(0, 'FX Devices', 'LFO Shape' .. I .. 'Node ' .. i ..
+                                            '.ctrlY = ', v.ctrlY or '')
                                     end
                                 end
 
                                 local function Track_Shapes()
                                     local Shapes = {}
-                                    local HowManySavedShapes = GetTrkSavedInfo ('LFO Saved Shape Count')
-                                    
+                                    local HowManySavedShapes = GetTrkSavedInfo('LFO Saved Shape Count')
 
-                                    for I=1, HowManySavedShapes or 0, 1 do 
+
+                                    for I = 1, HowManySavedShapes or 0, 1 do
                                         local Shape = {}
-                                        local Ct = GetTrkSavedInfo ('Shape'..I..'LFO Node Count = ')
+                                        local Ct = GetTrkSavedInfo('Shape' .. I .. 'LFO Node Count = ')
 
-                                        for i=1, Ct or 1  , 1 do 
-                                            Shape[i] =  Shape[i] or {}
-                                            Shape[i].x =     GetTrkSavedInfo ('Shape'..I..'Node '..i.. 'x = ')
-                                            Shape[i].y =     GetTrkSavedInfo ('Shape'..I..'Node '..i.. 'y = ')
-                                            Shape[i].ctrlX = GetTrkSavedInfo ('Shape'..I..'Node '..i.. '.ctrlX = ' )
-                                            Shape[i].ctrlY = GetTrkSavedInfo ('Shape'..I..'Node '..i.. '.ctrlY = ' )
+                                        for i = 1, Ct or 1, 1 do
+                                            Shape[i] = Shape[i] or {}
+                                            Shape[i].x = GetTrkSavedInfo('Shape' .. I .. 'Node ' .. i .. 'x = ')
+                                            Shape[i].y = GetTrkSavedInfo('Shape' .. I .. 'Node ' .. i .. 'y = ')
+                                            Shape[i].ctrlX = GetTrkSavedInfo('Shape' .. I .. 'Node ' .. i .. '.ctrlX = ')
+                                            Shape[i].ctrlY = GetTrkSavedInfo('Shape' .. I .. 'Node ' .. i .. '.ctrlY = ')
                                         end
-                                        if Shape[1] then 
+                                        if Shape[1] then
                                             table.insert(Shapes, Shape)
                                         end
                                     end
 
                                     if LFO.DeleteShape then
-                                        local Count = GetTrkSavedInfo ('LFO Saved Shape Count')
-                                        r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: LFO Saved Shape Count' , Count-1 , true ) 
+                                        local Count = GetTrkSavedInfo('LFO Saved Shape Count')
+                                        r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: LFO Saved Shape Count', Count - 1,
+                                            true)
                                         table.remove(Shapes, LFO.DeleteShape)
-                                        
-                                        for  I, V in ipairs(Shapes) do -- do for every shape
+
+                                        for I, V in ipairs(Shapes) do -- do for every shape
                                             for i, v in ipairs(V) do  --- do for every node
-                                                if i ==1 then 
-                                                    r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Shape'..I..'LFO Node Count = ', #V, true)
+                                                if i == 1 then
+                                                    r.GetSetMediaTrackInfo_String(LT_Track,
+                                                        'P_EXT: Shape' .. I .. 'LFO Node Count = ', #V, true)
                                                 end
 
-                                                r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Shape'..I..'Node '..i.. 'x = ', v.x or '', true)
-                                                r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Shape'..I..'Node '..i.. 'y = ', v.y or '', true)
+                                                r.GetSetMediaTrackInfo_String(LT_Track,
+                                                    'P_EXT: Shape' .. I .. 'Node ' .. i .. 'x = ', v.x or '', true)
+                                                r.GetSetMediaTrackInfo_String(LT_Track,
+                                                    'P_EXT: Shape' .. I .. 'Node ' .. i .. 'y = ', v.y or '', true)
 
-                                                r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Shape'..I..'Node '..i.. '.ctrlX = ' , v.ctrlX or '' ,true)
-                                                r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: Shape'..I..'Node '..i.. '.ctrlY = ' , v.ctrlY or '' ,true)
-
+                                                r.GetSetMediaTrackInfo_String(LT_Track,
+                                                    'P_EXT: Shape' .. I .. 'Node ' .. i .. '.ctrlX = ', v.ctrlX or '',
+                                                    true)
+                                                r.GetSetMediaTrackInfo_String(LT_Track,
+                                                    'P_EXT: Shape' .. I .. 'Node ' .. i .. '.ctrlY = ', v.ctrlY or '',
+                                                    true)
                                             end
                                         end
-                                        LFO.DeleteShape = nil 
+                                        LFO.DeleteShape = nil
                                     end
-                                    
-                                    DrawShapesInSelector(Shapes)
 
+                                    DrawShapesInSelector(Shapes)
                                 end
                                 local function Proj_Shapes()
                                     local Shapes = {}
-                                    local HowManySavedShapes = getProjSavedInfo ('LFO Saved Shape Count')
+                                    local HowManySavedShapes = getProjSavedInfo('LFO Saved Shape Count')
 
-                                    for I=1, HowManySavedShapes or 0, 1 do 
+                                    for I = 1, HowManySavedShapes or 0, 1 do
                                         local Shape = {}
-                                        local Ct = getProjSavedInfo ('LFO Shape'..I..'Node Count = ')
-                                        for i=1, Ct or 1  , 1 do 
-                                            Shape[i] =  Shape[i] or {}
-                                            Shape[i].x =     getProjSavedInfo ('LFO Shape'..I..'Node '..i.. 'x = ')
-                                            Shape[i].y =     getProjSavedInfo ('LFO Shape'..I..'Node '..i.. 'y = ')
-                                            Shape[i].ctrlX = getProjSavedInfo ('LFO Shape'..I..'Node '..i.. '.ctrlX = ' )
-                                            Shape[i].ctrlY = getProjSavedInfo ('LFO Shape'..I..'Node '..i.. '.ctrlY = ' )
+                                        local Ct = getProjSavedInfo('LFO Shape' .. I .. 'Node Count = ')
+                                        for i = 1, Ct or 1, 1 do
+                                            Shape[i] = Shape[i] or {}
+                                            Shape[i].x = getProjSavedInfo('LFO Shape' .. I .. 'Node ' .. i .. 'x = ')
+                                            Shape[i].y = getProjSavedInfo('LFO Shape' .. I .. 'Node ' .. i .. 'y = ')
+                                            Shape[i].ctrlX = getProjSavedInfo('LFO Shape' .. I ..
+                                                'Node ' .. i .. '.ctrlX = ')
+                                            Shape[i].ctrlY = getProjSavedInfo('LFO Shape' .. I ..
+                                                'Node ' .. i .. '.ctrlY = ')
                                         end
-                                        if Shape[1] then 
+                                        if Shape[1] then
                                             table.insert(Shapes, Shape)
                                         end
                                     end
 
                                     if LFO.DeleteShape then
-                                        local Count = getProjSavedInfo ('LFO Saved Shape Count')
-                                        r.SetProjExtState(0, 'FX Devices', 'LFO Saved Shape Count' , Count-1  ) 
+                                        local Count = getProjSavedInfo('LFO Saved Shape Count')
+                                        r.SetProjExtState(0, 'FX Devices', 'LFO Saved Shape Count', Count - 1)
                                         table.remove(Shapes, LFO.DeleteShape)
-                                        
-                                        for  I, V in ipairs(Shapes) do -- do for every shape
+
+                                        for I, V in ipairs(Shapes) do -- do for every shape
                                             for i, v in ipairs(V) do  --- do for every node
-                                                if i ==1 then 
-                                                    r.SetProjExtState(0, 'FX Devices', 'LFO Shape'..I..'Node Count = ', #V)
+                                                if i == 1 then
+                                                    r.SetProjExtState(0, 'FX Devices', 'LFO Shape' .. I ..
+                                                        'Node Count = ', #V)
                                                 end
 
-                                                 r.SetProjExtState(0, 'FX Devices', 'LFO Shape'..I..'Node '..i.. 'x = ', v.x or '')
-                                                 r.SetProjExtState(0, 'FX Devices', 'LFO Shape'..I..'Node '..i.. 'y = ', v.y or '')
+                                                r.SetProjExtState(0, 'FX Devices', 'LFO Shape' .. I ..
+                                                    'Node ' .. i .. 'x = ', v.x or '')
+                                                r.SetProjExtState(0, 'FX Devices', 'LFO Shape' .. I ..
+                                                    'Node ' .. i .. 'y = ', v.y or '')
 
-                                                 r.SetProjExtState(0, 'FX Devices', 'LFO Shape'..I..'Node '..i.. '.ctrlX = ' , v.ctrlX or '' )
-                                                 r.SetProjExtState(0, 'FX Devices', 'LFO Shape'..I..'Node '..i.. '.ctrlY = ' , v.ctrlY or '' )
-
+                                                r.SetProjExtState(0, 'FX Devices',
+                                                    'LFO Shape' .. I .. 'Node ' .. i .. '.ctrlX = ', v.ctrlX or '')
+                                                r.SetProjExtState(0, 'FX Devices',
+                                                    'LFO Shape' .. I .. 'Node ' .. i .. '.ctrlY = ', v.ctrlY or '')
                                             end
                                         end
-                                        LFO.DeleteShape = nil 
+                                        LFO.DeleteShape = nil
                                     end
-                                    
+
                                     DrawShapesInSelector(Shapes)
+                                end
 
-                                end 
-
-                                if r.ImGui_ImageButton(ctx, '## save' .. Macro, Img.Save, 12, 12, nil, nil, nil, nil, ClrBG, ClrTint) then 
-                                    if LFO.OpenedTab == 'Global' then 
-                                        LFO.OpenSaveDialog= Macro 
-                                    elseif LFO.OpenedTab == 'Project' then 
+                                if r.ImGui_ImageButton(ctx, '## save' .. Macro, Img.Save, 12, 12, nil, nil, nil, nil, ClrBG, ClrTint) then
+                                    if LFO.OpenedTab == 'Global' then
+                                        LFO.OpenSaveDialog = Macro
+                                    elseif LFO.OpenedTab == 'Project' then
                                         Save_Shape_To_Project()
                                     elseif LFO.OpenedTab == 'Track' then
                                         Save_Shape_To_Track()
@@ -3566,22 +3590,21 @@ function loop()
                                 SL()
                                 r.ImGui_AlignTextToFramePadding(ctx)
 
-    
-                                if r.ImGui_BeginTabBar(ctx, 'shape select tab bar') then 
-                                    
-                                    if r.ImGui_BeginTabItem(ctx, 'Global') then 
-                                        Global_Shapes ()
+
+                                if r.ImGui_BeginTabBar(ctx, 'shape select tab bar') then
+                                    if r.ImGui_BeginTabItem(ctx, 'Global') then
+                                        Global_Shapes()
                                         LFO.OpenedTab = 'Global'
                                         r.ImGui_EndTabItem(ctx)
                                     end
-    
-                                    if r.ImGui_BeginTabItem(ctx, 'Project') then 
+
+                                    if r.ImGui_BeginTabItem(ctx, 'Project') then
                                         Proj_Shapes()
                                         LFO.OpenedTab = 'Project'
                                         r.ImGui_EndTabItem(ctx)
                                     end
-    
-                                    if r.ImGui_BeginTabItem(ctx, 'Track') then 
+
+                                    if r.ImGui_BeginTabItem(ctx, 'Track') then
                                         Track_Shapes()
                                         LFO.OpenedTab = 'Track'
                                         r.ImGui_EndTabItem(ctx)
@@ -3590,9 +3613,10 @@ function loop()
                                     r.ImGui_EndTabBar(ctx)
                                 end
 
-                                if r.ImGui_IsWindowHovered(ctx,r.ImGui_FocusedFlags_RootAndChildWindows()) then 
-                                    LFO.HoveringShapeWin = Macro 
-                                else LFO.HoveringShapeWin = nil 
+                                if r.ImGui_IsWindowHovered(ctx, r.ImGui_FocusedFlags_RootAndChildWindows()) then
+                                    LFO.HoveringShapeWin = Macro
+                                else
+                                    LFO.HoveringShapeWin = nil
                                 end
                                 r.ImGui_End(ctx)
                             end
@@ -3604,46 +3628,41 @@ function loop()
 
 
                         return tweaking, All_Coord
-                       
-                        
                     end
 
-
-                    
-                    local HvrOnBtn = r.ImGui_IsItemHovered(ctx) 
-                    local PinID = TrkID..'Macro = '..Macro
-                    if HvrOnBtn or LFO.HvringWin == Macro or LFO.Tweaking == Macro or LFO.Pin == PinID or LFO.OpenSaveDialog==Macro or LFO.HoveringShapeWin ==Macro  then  
+                    local HvrOnBtn = r.ImGui_IsItemHovered(ctx)
+                    local PinID = TrkID .. 'Macro = ' .. Macro
+                    if HvrOnBtn or LFO.HvringWin == Macro or LFO.Tweaking == Macro or LFO.Pin == PinID or LFO.OpenSaveDialog == Macro or LFO.HoveringShapeWin == Macro then
                         LFO.notHvrTime = 0
-                        LFO.Tweaking =  open_LFO_Win(Track, Macro)
+                        LFO.Tweaking = open_LFO_Win(Track, Macro)
                         LFO.WinHovered = Macro
                     end
-                    
+
                     --- open window for 10 more frames after mouse left window or btn
-                    if LFO.WinHovered == Macro and not HvrOnBtn and not LFO.HvringWin and not LFO.Tweaking and not LFO.DontOpenNextFrame then  
-                        
+                    if LFO.WinHovered == Macro and not HvrOnBtn and not LFO.HvringWin and not LFO.Tweaking and not LFO.DontOpenNextFrame then
                         LFO.notHvrTime = LFO.notHvrTime + 1
-                        
-                        if LFO.notHvrTime > 0 and LFO.notHvrTime < 10 then 
+
+                        if LFO.notHvrTime > 0 and LFO.notHvrTime < 10 then
                             open_LFO_Win(Track, Macro)
-                        else 
+                        else
                             LFO.notHvrTime = 0
-                            LFO.WinHovered = nil     
+                            LFO.WinHovered = nil
                         end
                     end
-                    LFO.DontOpenNextFrame = nil 
+                    LFO.DontOpenNextFrame = nil
 
 
-                    
+
 
 
                     if not IsLBtnHeld then
                         LFO_DragDir = nil
                         LFO_MsX_Start, LFO_MsY_Start = nil
                     end
-                    
-                    --[[ if Mc.All_Coord then 
+
+                    --[[ if Mc.All_Coord then
                         if TrkID ~= TrkID_End and TrkID_End ~= nil and Sel_Track_FX_Count > 0 then
-                            for i  , v in ipairs(Mc.All_Coord.X) do 
+                            for i  , v in ipairs(Mc.All_Coord.X) do
                                 msg(i)
                                 r.gmem_write(4, 15) -- mode 15 tells jsfx to retrieve all coordinates
                                 r.gmem_write(5, Macro)
@@ -3657,7 +3676,7 @@ function loop()
 
 
                     ---- this part draws modulation histogram (Deprecated)
-                   --[[  local MOD = math.abs(SetMinMax(r.gmem_read(100 + i) / 127, -1, 1)) 
+                    --[[  local MOD = math.abs(SetMinMax(r.gmem_read(100 + i) / 127, -1, 1))
                     Mc.StepV = Mc.StepV or {}
                     table.insert(Mc.StepV, MOD* Mc.Gain * 4)
 
@@ -3670,65 +3689,59 @@ function loop()
                             T + H - (Mc.StepV[s] or 0), EightColors.LFO[i], 2)
                         --r.ImGui_DrawList_PathLineTo(WDL, L+s,  Y_Mid+math.sin(s/Mc.Freq) * Mc.Gain)
                     end ]]
-                    if LFO.OpenSaveDialog==Macro then 
-                        r.ImGui_OpenPopup(ctx,  'Decide Name')
-                        r.ImGui_SetNextWindowPos(ctx, L  ,T-LFO.DummyH)
-                        r.ImGui_SetNextWindowFocus( ctx)
+                    if LFO.OpenSaveDialog == Macro then
+                        r.ImGui_OpenPopup(ctx, 'Decide Name')
+                        r.ImGui_SetNextWindowPos(ctx, L, T - LFO.DummyH)
+                        r.ImGui_SetNextWindowFocus(ctx)
 
-                        if r.ImGui_BeginPopupModal( ctx, 'Decide Name',  true ,r.ImGui_WindowFlags_NoTitleBar()|r.ImGui_WindowFlags_AlwaysAutoResize()) then 
+                        if r.ImGui_BeginPopupModal(ctx, 'Decide Name', true, r.ImGui_WindowFlags_NoTitleBar()|r.ImGui_WindowFlags_AlwaysAutoResize()) then
                             r.ImGui_Text(ctx, 'Enter a name for the shape: ')
                             --[[ r.ImGui_Text(ctx, '(?)')
-                            if r.ImGui_IsItemHovered(ctx) then 
+                            if r.ImGui_IsItemHovered(ctx) then
                                 tooltip('use / in file name to save into sub-directories')
                             end ]]
 
-                            r.ImGui_SetNextItemWidth(ctx, LFO.Def.DummyW)  
-                             r.ImGui_SetKeyboardFocusHere(ctx)  
-                            local rv, buf =  r.ImGui_InputText(ctx, buf or '##Name' ,buf)
-                            r.ImGui_Button(ctx,'Enter')
-                            if  r.ImGui_IsItemClicked(ctx) or (r.ImGui_IsItemFocused(ctx) and r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_Enter()) and Mods == 0) then 
-                                local LFO_Name = buf 
+                            r.ImGui_SetNextItemWidth(ctx, LFO.Def.DummyW)
+                            r.ImGui_SetKeyboardFocusHere(ctx)
+                            local rv, buf = r.ImGui_InputText(ctx, buf or '##Name', buf)
+                            r.ImGui_Button(ctx, 'Enter')
+                            if r.ImGui_IsItemClicked(ctx) or (r.ImGui_IsItemFocused(ctx) and r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_Enter()) and Mods == 0) then
+                                local LFO_Name = buf
                                 local path = ConcatPath(CurrentDirectory, 'src', 'LFO Shapes')
-                                local file_path = ConcatPath(path, LFO_Name..'.ini')
+                                local file_path = ConcatPath(path, LFO_Name .. '.ini')
                                 local file = io.open(file_path, 'w')
-                                
-                                
-                                for i, v in ipairs(Mc.Node) do 
-                                    if i ==1 then 
+
+
+                                for i, v in ipairs(Mc.Node) do
+                                    if i == 1 then
                                         file:write('Total Number Of Nodes = ', #Mc.Node, '\n')
                                     end
-                                    file:write(i , '.x = ' , v.x , '\n') 
-                                    file:write(i , '.y = ' , v.y , '\n') 
-                                    if v.ctrlX and v.ctrlY then 
-                                        file:write(i , '.ctrlX = ' , v.ctrlX , '\n') 
-                                        file:write(i , '.ctrlY = ' , v.ctrlY , '\n') 
-
+                                    file:write(i, '.x = ', v.x, '\n')
+                                    file:write(i, '.y = ', v.y, '\n')
+                                    if v.ctrlX and v.ctrlY then
+                                        file:write(i, '.ctrlX = ', v.ctrlX, '\n')
+                                        file:write(i, '.ctrlY = ', v.ctrlY, '\n')
                                     end
-                                    file:write( '\n')
-
+                                    file:write('\n')
                                 end
 
-                                LFO.OpenSaveDialog = nil 
+                                LFO.OpenSaveDialog = nil
                                 r.ImGui_CloseCurrentPopup(ctx)
                             end
                             SL()
-                            r.ImGui_Button(ctx,'Cancel (Esc)')
-                            if r.ImGui_IsItemClicked(ctx) or r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_Escape()) then 
+                            r.ImGui_Button(ctx, 'Cancel (Esc)')
+                            if r.ImGui_IsItemClicked(ctx) or r.ImGui_IsKeyPressed(ctx, r.ImGui_Key_Escape()) then
                                 r.ImGui_CloseCurrentPopup(ctx)
-                                LFO.OpenSaveDialog = nil 
+                                LFO.OpenSaveDialog = nil
                             end
 
-                            
+
 
                             r.ImGui_EndPopup(ctx)
-        
                         end
                     end
-                        
-                    
-
                 end
-                
+
 
 
 
@@ -3806,12 +3819,12 @@ function loop()
                     if r.ImGui_Selectable(ctx, 'Automate', false) then
                         AddMacroJSFX()
                         -- Show Envelope for Morph Slider
-                        local env = r.GetFXEnvelope(LT_Track, 0, i - 1, false) -- Check if envelope is on
-                        if env == nil then  -- Envelope is off
+                        local env = r.GetFXEnvelope(LT_Track, 0, i - 1, false)    -- Check if envelope is on
+                        if env == nil then                                        -- Envelope is off
                             local env = r.GetFXEnvelope(LT_Track, 0, i - 1, true) -- true = Create envelope
-                        else -- Envelope is on
+                        else                                                      -- Envelope is on
                             local rv, EnvelopeStateChunk = r.GetEnvelopeStateChunk(env, "", false)
-                            if string.find(EnvelopeStateChunk, "VIS 1") then -- VIS 1 = visible, VIS 0 = invisible
+                            if string.find(EnvelopeStateChunk, "VIS 1") then      -- VIS 1 = visible, VIS 0 = invisible
                                 EnvelopeStateChunk = string.gsub(EnvelopeStateChunk, "VIS 1", "VIS 0")
                                 r.SetEnvelopeStateChunk(env, EnvelopeStateChunk, false)
                             else -- on but invisible
@@ -3821,7 +3834,7 @@ function loop()
                         end
                         SetPrmAlias(LT_TrackNum, 1, i, Trk[TrkID].Mod[i].Name or ('Macro' .. i)) -- Change parameter name to alias
                         r.TrackList_AdjustWindows(false)
-                        r.UpdateArrange()  
+                        r.UpdateArrange()
                     end
                     SetTypeToEnv()
                     SetTypeToStepSEQ()
@@ -4044,7 +4057,24 @@ function loop()
             local spaceIfPreFX = 0
             if Trk[TrkID].PreFX[1] and Trk[TrkID].PostFX[1] and not Trk[TrkID].PostFX_Hide then spaceIfPreFX = 20 end
 
-            if Wheel_V ~= 0 and not DisableScroll then r.ImGui_SetNextWindowScroll(ctx, -CursorStartX + Wheel_V * 10, 0) end
+            if Wheel_V ~= 0 and not DisableScroll and focused_window == 'FX Devices' then
+                r.JS_Window_SetFocus(hwnd)
+                if Ctrl_Scroll then
+                    if Mods == Ctrl then
+                        Horizontal_Scroll(20)
+                    elseif Mods == Ctrl + Shift then
+                        Horizontal_Scroll(10)
+                    elseif Mods == Shift then -- to prevent a weird behavior which is not related to Horizontal_Scroll function
+                        r.ImGui_SetNextWindowScroll(ctx, -CursorStartX, 0)
+                    end
+                else
+                    if Mods == 0 then -- 0 = not mods key
+                        Horizontal_Scroll(20)
+                    elseif Mods == Shift then
+                        Horizontal_Scroll(10)
+                    end
+                end
+            end
 
             MainWin_Flg = r.ImGui_WindowFlags_HorizontalScrollbar() + FX_DeviceWindow_NoScroll
 
@@ -4053,8 +4083,8 @@ function loop()
                 ----- Loop for every FX on the track -----------------
                 ------------------------------------------------------
 
-                
-                
+
+
 
 
                 CursorStartX = r.ImGui_GetCursorStartPos(ctx)
@@ -4089,14 +4119,13 @@ function loop()
                     end
 
                     FXGUID_To_Check_If_InLayer = r.TrackFX_GetFXGUID(LT_Track, FX_Idx)
-                    local SpcW 
+                    local SpcW
                     if not tablefind(Trk[TrkID].PostFX, FxGUID) and FXGUID[FX_Idx] ~= FXGUID[FX_Idx - 1] then
                         if FX.InLyr[FXGUID_To_Check_If_InLayer] == nil           --not in layer
                             and FindStringInTable(BlackListFXs, FX_Name) ~= true -- not blacklisted
                             and string.find(FX_Name, 'RackMixer') == nil
                             and FX_Idx ~= RepeatTimeForWindows                   --not last fx
                             and not FX[FxGUID].InWhichBand --[[Not in Band Split]] then
-
                             local Idx = FX_Idx
                             if FX_Idx == 1 then
                                 local Nm = FX.Win_Name[0]
@@ -4104,12 +4133,8 @@ function loop()
                             end
                             local CurX = r.ImGui_GetCursorPosX(ctx)
 
-                            
+
                             local SpcW = AddSpaceBtwnFXs(Idx)
-
-
-
-
                         elseif FX.InLyr[FXGUID_To_Check_If_InLayer] == FXGUID[FX_Idx] and FXGUID[FX_Idx] then
                             AddSpaceBtwnFXs(FX_Idx, true)
                         elseif FX_Idx == RepeatTimeForWindows then
@@ -4136,7 +4161,7 @@ function loop()
 
                     if --[[Normal Window]] (not string.find(FX_Name, 'FXD %(Mix%)RackMixer')) and FX.InLyr[FXGUID[FX_Idx]] == nil and FX_Idx ~= RepeatTimeForWindows and FindStringInTable(BlackListFXs, FX_Name) ~= true then
                         --FX_IdxREAL =  FX_Idx+Lyr.FX_Ins[FXGUID[FX_Idx]]
-                        Tab_Collapse_Win = false 
+                        Tab_Collapse_Win = false
 
                         if not tablefind(Trk[TrkID].PostFX, FxGUID) and not FX[FxGUID].InWhichBand then
                             createFXWindow(FX_Idx)
@@ -4293,7 +4318,7 @@ function loop()
                                         local D = FX[FxGUID].Draw
                                         local FullWidth = -50
 
-                                        local typelbl; local It = Draw.SelItm 
+                                        local typelbl; local It = Draw.SelItm
                                         --D[It or 1] = D[It or 1] or {}
 
 
@@ -4319,22 +4344,28 @@ function loop()
                                             r.ImGui_EndCombo(ctx)
                                         end
 
-                                        if It then 
-                                            
+                                        if It then
                                             r.ImGui_Text(ctx, 'Color :')
                                             r.ImGui_SameLine(ctx)
                                             if Draw.SelItm and D[It].clr then
-                                                clrpick, D[It].clr = r.ImGui_ColorEdit4(ctx, '##', D[It].clr or 0xffffffff, r.ImGui_ColorEditFlags_NoInputs()|r.ImGui_ColorEditFlags_AlphaPreviewHalf()|r.ImGui_ColorEditFlags_AlphaBar())
-
+                                                clrpick, D[It].clr = r.ImGui_ColorEdit4(ctx, '##',
+                                                    D[It].clr or 0xffffffff,
+                                                    r.ImGui_ColorEditFlags_NoInputs()|
+                                                    r.ImGui_ColorEditFlags_AlphaPreviewHalf()|
+                                                    r.ImGui_ColorEditFlags_AlphaBar())
                                             else
-                                                clrpick, Draw.clr = r.ImGui_ColorEdit4(ctx, '##', Draw.clr or 0xffffffff, r.ImGui_ColorEditFlags_NoInputs()|r.ImGui_ColorEditFlags_AlphaPreviewHalf()|r.ImGui_ColorEditFlags_AlphaBar())
+                                                clrpick, Draw.clr = r.ImGui_ColorEdit4(ctx, '##', Draw.clr or 0xffffffff,
+                                                    r.ImGui_ColorEditFlags_NoInputs()|
+                                                    r.ImGui_ColorEditFlags_AlphaPreviewHalf()|
+                                                    r.ImGui_ColorEditFlags_AlphaBar())
                                             end
                                             r.ImGui_Text(ctx, 'Default edge rounding :')
                                             r.ImGui_SameLine(ctx)
                                             r.ImGui_SetNextItemWidth(ctx, 40)
 
                                             FX[FxGUID].Draw = FX[FxGUID].Draw or {}
-                                            EditER, FX[FxGUID].Draw.Df_EdgeRound = r.ImGui_DragDouble(ctx, '##' .. FxGUID, FX[FxGUID].Draw.Df_EdgeRound, 0.05, 0, 30, '%.2f')
+                                            EditER, FX[FxGUID].Draw.Df_EdgeRound = r.ImGui_DragDouble(ctx, '##' .. FxGUID,
+                                                FX[FxGUID].Draw.Df_EdgeRound, 0.05, 0, 30, '%.2f')
 
 
 
@@ -4385,16 +4416,18 @@ function loop()
                                                 r.ImGui_SameLine(ctx)
                                                 local CurX = r.ImGui_GetCursorPosX(ctx)
                                                 r.ImGui_SetNextItemWidth(ctx, FullWidth)
-                                                _, D[It].L = r.ImGui_DragDouble(ctx, '##' .. Draw.SelItm .. 'L', D[It].L, 1, 0, Win_W, '%.0f')
+                                                _, D[It].L = r.ImGui_DragDouble(ctx, '##' .. Draw.SelItm .. 'L', D[It].L,
+                                                    1, 0, Win_W, '%.0f')
                                                 if D[It].Type ~= 'V-line' and D[It].Type ~= 'circle' and D[It].Type ~= 'circle fill' then
                                                     r.ImGui_Text(ctx, 'End Pos X:')
                                                     r.ImGui_SetNextItemWidth(ctx, FullWidth)
 
                                                     r.ImGui_SameLine(ctx, CurX)
-                                                    _, D[It].R = r.ImGui_DragDouble(ctx, '##' .. Draw.SelItm .. 'R', D[It].R, 1, 0, Win_W, '%.0f')
+                                                    _, D[It].R = r.ImGui_DragDouble(ctx, '##' .. Draw.SelItm .. 'R',
+                                                        D[It].R, 1, 0, Win_W, '%.0f')
                                                 end
 
-                                                if D[It].Type == 'circle' or D[It].Type  == 'circle fill' then
+                                                if D[It].Type == 'circle' or D[It].Type == 'circle fill' then
                                                     r.ImGui_Text(ctx, 'Radius:')
                                                     r.ImGui_SameLine(ctx)
                                                     r.ImGui_SetNextItemWidth(ctx, FullWidth)
@@ -4450,7 +4483,8 @@ function loop()
                                         r.ImGui_PopStyleColor(ctx)
                                     end
                                 elseif LE.Sel_Items[1] then
-                                    local ID, TypeID; local FrstSelItm = FX[FxGUID][LE.Sel_Items[1]]; local FItm = LE.Sel_Items[1]
+                                    local ID, TypeID; local FrstSelItm = FX[FxGUID][LE.Sel_Items[1]]; local FItm = LE
+                                        .Sel_Items[1]
                                     local R_ofs = 50
                                     if LE.Sel_Items[1] and not LE.Sel_Items[2] then
                                         ID       = FxGUID .. LE.Sel_Items[1]
@@ -4835,13 +4869,20 @@ function loop()
                                     end
 
 
-                                    if FrstSelItm.Type ~= 'Knob' then 
+                                    if FrstSelItm.Type ~= 'Knob' then
                                         SL()
-                                        r.ImGui_Text(ctx, 'Height: ') SL()
+                                        r.ImGui_Text(ctx, 'Height: ')
+                                        SL()
                                         r.ImGui_SetNextItemWidth(ctx, 60)
-                                        local max , defaultH 
-                                        if FrstSelItm.Type == 'V-Slider' then max = 200  defaultH = 160 end 
-                                        local _, W = r.ImGui_DragDouble(ctx, '##Height'.. FxGUID .. (LE.Sel_Items[1] or ''), FX[FxGUID][LE.Sel_Items[1] or ''].Height or defaultH or 3, LE.GridSize / 4, -5 , max or 40 ,'%.1f')
+                                        local max, defaultH
+                                        if FrstSelItm.Type == 'V-Slider' then
+                                            max = 200
+                                            defaultH = 160
+                                        end
+                                        local _, W = r.ImGui_DragDouble(ctx,
+                                            '##Height' .. FxGUID .. (LE.Sel_Items[1] or ''),
+                                            FX[FxGUID][LE.Sel_Items[1] or ''].Height or defaultH or 3, LE.GridSize / 4,
+                                            -5, max or 40, '%.1f')
                                         if r.ImGui_IsItemEdited(ctx) then
                                             for i, v in pairs(LE.Sel_Items) do
                                                 FX[FxGUID][v].Height = W
@@ -4875,7 +4916,7 @@ function loop()
                                         end
                                     end
 
-                                    
+
 
 
 
@@ -4962,7 +5003,6 @@ function loop()
 
                                     SL()
                                     if r.ImGui_BeginChildFrame(ctx, '##drop_files', -R_ofs, 20) then
-                                        
                                         if not FrstSelItm.ImagePath then
                                             r.ImGui_Text(ctx, 'Drag and drop files here...')
                                         else
@@ -4994,11 +5034,11 @@ function loop()
 
                                                     local NewFileName = r.GetResourcePath() .. 'src/Images/' ..  SubFolder .. filename:sub(index)
                                                     CopyFile(filename, NewFileName) ]]
-                                                    if FrstSelItm.Type == 'Knob' then 
+                                                    if FrstSelItm.Type == 'Knob' then
                                                         AbsPath, FrstSelItm.ImagePath = CopyImageFile(filename, 'Knobs')
-                                                    elseif FrstSelItm.Type == 'Switch' then 
-                                                        AbsPath, FrstSelItm.ImagePath = CopyImageFile(filename, 'Switches')
-
+                                                    elseif FrstSelItm.Type == 'Switch' then
+                                                        AbsPath, FrstSelItm.ImagePath = CopyImageFile(filename,
+                                                            'Switches')
                                                     end
                                                     ToAllSelItm('Image', r.ImGui_CreateImage(AbsPath))
                                                 end
@@ -5089,7 +5129,7 @@ function loop()
                                             SetStyle('Default', Style)
                                             SetStyle('Minimalistic', 'Pro C')
                                             SetStyle('Invisible', 'Invisible')
-                                            local Dir = CurrentDirectory .. 'src/Images/Knobs' 
+                                            local Dir = CurrentDirectory .. 'src/Images/Knobs'
                                             if r.ImGui_IsWindowAppearing(ctx) then
                                                 StyleWindowImgFiles = scandir(Dir)
                                                 if StyleWindowImgFiles then
@@ -5105,7 +5145,8 @@ function loop()
 
                                             for i, v in pairs(StyleWinImg) do
                                                 local Dir = '/Scripts/FX Devices/BryanChi_FX_Devices/src/Images/Knobs/'
-                                                SetStyle(StyleWinImgName[i], 'Custom Image', StyleWinImg[i], Dir.. StyleWinImgName[i])
+                                                SetStyle(StyleWinImgName[i], 'Custom Image', StyleWinImg[i],
+                                                    Dir .. StyleWinImgName[i])
                                             end
                                         end
 
@@ -5215,7 +5256,8 @@ function loop()
                                         local DragLbl_Clr_Edited, V_Clr = r.ImGui_ColorEdit4(ctx,
                                             '##Switch on Clr' .. LE.Sel_Items[1],
                                             FX[FxGUID][LE.Sel_Items[1] or ''].Switch_On_Clr or 0xffffff55,
-                                            r.ImGui_ColorEditFlags_NoInputs()| r.ImGui_ColorEditFlags_AlphaPreviewHalf()|r.ImGui_ColorEditFlags_AlphaBar())
+                                            r.ImGui_ColorEditFlags_NoInputs()| r.ImGui_ColorEditFlags_AlphaPreviewHalf()|
+                                            r.ImGui_ColorEditFlags_AlphaBar())
                                         if DragLbl_Clr_Edited then
                                             for i, v in pairs(LE.Sel_Items) do FX[FxGUID][v].Switch_On_Clr = V_Clr end
                                         end
@@ -5503,16 +5545,19 @@ function loop()
                                                     return r.ImGui_IsItemActive(ctx)
                                                 end
 
-                                                local BL_Width = { 'Knob Pointer', 'Knob Range' , 'Gain Reduction Text' }
-                                                local BL_Height = { 'Knob Pointer', 'Knob Range', 'Circle', 'Circle Filled', 'Knob Circle', 'Knob Image','Gain Reduction Text' }
+                                                local BL_Width = { 'Knob Pointer', 'Knob Range', 'Gain Reduction Text' }
+                                                local BL_Height = { 'Knob Pointer', 'Knob Range', 'Circle',
+                                                    'Circle Filled', 'Knob Circle', 'Knob Image', 'Gain Reduction Text' }
                                                 local Thick = { 'Knob Pointer', 'Line', 'Rect', 'Circle' }
                                                 local Round = { 'Rect', 'Rect Filled' }
                                                 local Gap = { 'Circle', 'Circle Filled', 'Knob Range' }
-                                                local BL_XYGap = { 'Knob Pointer', 'Knob Range', 'Knob Circle', 'Knob Image' }
+                                                local BL_XYGap = { 'Knob Pointer', 'Knob Range', 'Knob Circle',
+                                                    'Knob Image' }
                                                 local RadiusInOut = { 'Knob Pointer', 'Knob Range' }
                                                 local Radius = { 'Knob Circle', 'Knob Image' }
-                                                local BL_Repeat = { 'Knob Range', 'Knob Circle', 'Knob Image','Knob Pointer','Gain Reduction Text' }
-                                                local GR_Text = {'Gain Reduction Text'}
+                                                local BL_Repeat = { 'Knob Range', 'Knob Circle', 'Knob Image',
+                                                    'Knob Pointer', 'Gain Reduction Text' }
+                                                local GR_Text = { 'Gain Reduction Text' }
 
 
                                                 local X_Gap_Shown_Name = 'X Gap:'
@@ -5609,14 +5654,20 @@ function loop()
                                                         r.ImGui_PushItemWidth(ctx, -FLT_MIN)
 
                                                         local FORMAT = format
-                                                        if not D[Name..'_GR'] and not D[Name] and not defaultV then FORMAT = '' end
+                                                        if not D[Name .. '_GR'] and not D[Name] and not defaultV then
+                                                            FORMAT =
+                                                            ''
+                                                        end
 
                                                         local rv, V = r.ImGui_DragDouble(ctx, '##' .. Name .. LBL,
-                                                            D[Name..'_GR'] or D[Name] or defaultV, stepSize or LE.GridSize, min or -W,
+                                                            D[Name .. '_GR'] or D[Name] or defaultV,
+                                                            stepSize or LE.GridSize, min or -W,
                                                             max or W - 10, FORMAT)
 
-                                                        if rv and not D[Name..'_GR'] then D[Name] = V
-                                                        elseif rv and D[Name..'_GR'] then D[Name..'_GR'] = V ;   D[Name] = nil
+                                                        if rv and not D[Name .. '_GR'] then
+                                                            D[Name] = V
+                                                        elseif rv and D[Name .. '_GR'] then
+                                                            D[Name .. '_GR'] = V; D[Name] = nil
                                                         end
 
                                                         -- if want to show preview use this.
@@ -5627,25 +5678,27 @@ function loop()
                                                         if FrstSelItm.ShowPreview and r.ImGui_IsItemDeactivated(ctx) then FrstSelItm.ShowPreview = nil end
 
                                                         r.ImGui_PopItemWidth(ctx)
-                                                        if Name:find('_VA') then    
-                                                            if r.ImGui_IsItemClicked(ctx,1) and Mods == Ctrl then 
-                                                                r.ImGui_OpenPopup(ctx, 'Value afftect '..Name)
+                                                        if Name:find('_VA') then
+                                                            if r.ImGui_IsItemClicked(ctx, 1) and Mods == Ctrl then
+                                                                r.ImGui_OpenPopup(ctx, 'Value afftect ' .. Name)
                                                             end
                                                         end
 
-                                                        if r.ImGui_BeginPopup(ctx, 'Value afftect '..Name) then 
-                                                            local rv,GR = r.TrackFX_GetNamedConfigParm(LT_Track, FX_Idx, 'GainReduction_dB')
-                                                            if not rv then r.ImGui_BeginDisabled(ctx) end 
+                                                        if r.ImGui_BeginPopup(ctx, 'Value afftect ' .. Name) then
+                                                            local rv, GR = r.TrackFX_GetNamedConfigParm(LT_Track, FX_Idx,
+                                                                'GainReduction_dB')
+                                                            if not rv then r.ImGui_BeginDisabled(ctx) end
 
-                                                                if D[Name..'_GR'] then D.check = true end 
-                                                                 Check, D.check = r.ImGui_Checkbox(ctx,'Affected by Gain Reduction', D.check )
-                                                                if Check then 
-                                                                    if D[Name..'_GR'] then D[Name..'_GR'] = nil else D[Name..'_GR'] = 0 end 
-                                                                end
-                                                                if D.VA_by_GR then 
+                                                            if D[Name .. '_GR'] then D.check = true end
+                                                            Check, D.check = r.ImGui_Checkbox(ctx,
+                                                                'Affected by Gain Reduction', D.check)
+                                                            if Check then
+                                                                if D[Name .. '_GR'] then D[Name .. '_GR'] = nil else D[Name .. '_GR'] = 0 end
+                                                            end
+                                                            if D.VA_by_GR then
 
-                                                                end
-                                                            if not rv then r.ImGui_EndDisabled(ctx) end 
+                                                            end
+                                                            if not rv then r.ImGui_EndDisabled(ctx) end
                                                             r.ImGui_EndPopup(ctx)
                                                         end
 
@@ -5710,12 +5763,12 @@ function loop()
                                                         AddVal('Gap', 0, 0.2, 0, 300, '%.1f')
                                                         AddVal('Gap_VA', 0, 0.01, -1, 1)
                                                     end
-                                                    if D.Type ~= 'Gain Reduction Text' then 
-                                                        if SetRowName('X Gap', BL_XYGap)  then
+                                                    if D.Type ~= 'Gain Reduction Text' then
+                                                        if SetRowName('X Gap', BL_XYGap) then
                                                             AddVal('X_Gap', 0, 0.2, 0, 300, '%.1f')
                                                             AddVal('X_Gap_VA', 0, 0.01, -1, 1)
                                                         end
-                                                        if SetRowName('Y Gap', BL_XYGap)then
+                                                        if SetRowName('Y Gap', BL_XYGap) then
                                                             AddVal('Y_Gap', 0, 0.2, 0, 300, '%.1f')
                                                             AddVal('Y_Gap_VA', 0, 0.01, -1, 1)
                                                         end
@@ -5748,7 +5801,7 @@ function loop()
                                                     if SetRowName('Edge Round', nil, Round) then
                                                         AddVal('Round', 0, 0.1, 0, 100, '%.1f', true)
                                                     end
-                                                    --[[ if SetRowName('Font Size',GR_Text ) then 
+                                                    --[[ if SetRowName('Font Size',GR_Text ) then
 
                                                     end ]]
                                                     SetRowName('Color')
@@ -5759,7 +5812,8 @@ function loop()
                                                     if rv then D.Clr = Clr end
 
                                                     r.ImGui_TableSetColumnIndex(ctx, 2)
-                                                    local rv, Clr_VA = r.ImGui_ColorEdit4(ctx, 'Color_VA' .. LBL, D.Clr_VA or 0xffffffff, ClrFLG)
+                                                    local rv, Clr_VA = r.ImGui_ColorEdit4(ctx, 'Color_VA' .. LBL,
+                                                        D.Clr_VA or 0xffffffff, ClrFLG)
                                                     if rv then D.Clr_VA = Clr_VA end
 
 
@@ -5812,7 +5866,8 @@ function loop()
 
                                     r.ImGui_Text(ctx, 'Background Color:')
                                     r.ImGui_SameLine(ctx)
-                                    _, FX[FxGUID].BgClr = r.ImGui_ColorEdit4(ctx, '##' .. FxGUID .. 'BgClr', FX[FxGUID].BgClr or FX_Devices_Bg or 0x151515ff,
+                                    _, FX[FxGUID].BgClr = r.ImGui_ColorEdit4(ctx, '##' .. FxGUID .. 'BgClr',
+                                        FX[FxGUID].BgClr or FX_Devices_Bg or 0x151515ff,
                                         r.ImGui_ColorEditFlags_NoInputs()|    r.ImGui_ColorEditFlags_AlphaPreviewHalf()|
                                         r.ImGui_ColorEditFlags_AlphaBar())
                                     if FX[FxGUID].BgClr == r.ImGui_GetColor(ctx, r.ImGui_Col_FrameBg()) then
@@ -6021,7 +6076,8 @@ function loop()
                             Mx, My = r.ImGui_GetMousePos(ctx)
                             FDL = r.ImGui_GetForegroundDrawList(ctx)
 
-                            r.ImGui_DrawList_AddRectFilled(FDL, Draw.Rect.L, Draw.Rect.T, Draw.Rect.R, Draw.Rect.B, 0xbbbbbb66)
+                            r.ImGui_DrawList_AddRectFilled(FDL, Draw.Rect.L, Draw.Rect.T, Draw.Rect.R, Draw.Rect.B,
+                                0xbbbbbb66)
                         else
                             AdjustDrawRectPos = nil
                         end
@@ -7359,7 +7415,8 @@ function loop()
 
                                             if r.ImGui_IsMouseReleased(ctx, 0) then
                                                 local InsPos = Find_InsPos()
-                                                local rv, type, payload, is_preview, is_delivery = r.ImGui_GetDragDropPayload(ctx)
+                                                local rv, type, payload, is_preview, is_delivery = r
+                                                    .ImGui_GetDragDropPayload(ctx)
                                                 r.TrackFX_AddByName(LT_Track, payload, false, -1000 - InsPos - 1)
                                                 local FXid = r.TrackFX_GetFXGUID(LT_Track, InsPos + 1)
                                                 DropFXintoBS(FXid, FxGUID, i, InsPos, FX_Idx, 'DontMove')
@@ -8031,9 +8088,9 @@ function loop()
                                     if FP.WhichCC then
                                         for m = 1, 8, 1 do
                                             local Amt = FP.ModAMT[m]
-                                            if FP.ModBipolar[m] then   Amt = FP.ModAMT[m] + 100 end 
+                                            if FP.ModBipolar[m] then Amt = FP.ModAMT[m] + 100 end
 
-                                            if FP.ModAMT[m] then r.gmem_write(1000 * m + P,Amt  ) end
+                                            if FP.ModAMT[m] then r.gmem_write(1000 * m + P, Amt) end
                                         end
                                     end
                                 end
@@ -8353,7 +8410,6 @@ function loop()
                 end
             end
             Delete_All_FXD_AnalyzerFX(track)
-
         end
     end
     Track_Fetch_At_End = r.GetLastTouchedTrack()

--- a/BryanChi_FX_Devices/src/FX Layout Plugin Scripts/ReaDrum Machine.lua
+++ b/BryanChi_FX_Devices/src/FX Layout Plugin Scripts/ReaDrum Machine.lua
@@ -1,12 +1,10 @@
 -- @noindex
 -- @author Suzuki
 -- @link https://forum.cockos.com/showthread.php?t=284566
--- @version 1.2
+-- @version 1.4.4
 -- @changelog
--- + Added color tweak option
--- + Made each instance remember the state of vertical menu (which is open or closed)
--- + You can sweep vertical tabs to open the menu
--- # Fixed the PLink bug
+-- + Added midi octave name display ofsset support
+-- + Added volume adjustment for each pad (SHIFT + Left drag)
 -- @about ReaDrum Machine is a script which loads samples and FX from browser/arrange into subcontainers inside a container named ReaDrum Machine. 
 
 r = reaper
@@ -53,15 +51,16 @@ local function DndMoveFXtoPad_TARGET_SWAP(a)
     r.ImGui_EndDragDropTarget(ctx)
     r.Undo_BeginBlock()
     r.PreventUIRefresh(1)
-    GetDrumMachineIdx()
+    GetDrumMachineIdx(track)
     if FX_Drag and Mods == 0 then
         if Pad[a] then   -- add fx to target
           local dst_pad = Pad[a].Pad_ID
           local dst_num = Pad[a].Pad_Num
           -- dst_guid = Pad[a].Pad_GUID
           local dstfx_idx = CountPadFX(dst_num)
-          dstfx_idx = dstfx_idx + 1 -- the last slot being offset by 1
-          local dst_last = get_fx_id_from_container_path(track, parent_id, dst_num, dstfx_idx)
+          local dstfx_idx = dstfx_idx + 1 -- the last slot being offset by 1
+          local dst_id = ConvertPathToNestedPath(parent_id, dst_num)
+          local dst_last = ConvertPathToNestedPath(dst_id, dstfx_idx)
           r.TrackFX_CopyToTrack(LT_Track, DragFX_ID, LT_Track, dst_last, true) -- true = move
           r.PreventUIRefresh(-1)
           EndUndoBlock("ADD FX TO PAD")
@@ -69,8 +68,8 @@ local function DndMoveFXtoPad_TARGET_SWAP(a)
           CountPads()
           AddPad(note_name, a) -- dst
           AddNoteFilter(notenum, pad_num)
-          local previous_pad_id = get_fx_id_from_container_path(track, parent_id, pad_num - 1)
-          local next_pad_id = get_fx_id_from_container_path(track, parent_id, pad_num + 1)
+          local previous_pad_id = ConvertPathToNestedPath(parent_id, pad_num - 1)
+          local next_pad_id = ConvertPathToNestedPath(parent_id, pad_num + 1)
           Pad[a] = { -- dst
             Previous_Pad_ID = previous_pad_id,
             Pad_ID = pad_id,
@@ -80,8 +79,9 @@ local function DndMoveFXtoPad_TARGET_SWAP(a)
             Note_Num = notenum
           }
           local dstfx_idx = CountPadFX(pad_num) 
-          dstfx_idx = dstfx_idx + 1 -- the last slot being offset by 1
-          local dst_last = get_fx_id_from_container_path(track, parent_id, pad_num, dstfx_idx)
+          local dstfx_idx = dstfx_idx + 1 -- the last slot being offset by 1
+          local pad_id = ConvertPathToNestedPath(parent_id, pad_num)
+          local dst_last = ConvertPathToNestedPath(pad_id, dstfx_idx)
           r.TrackFX_CopyToTrack(LT_Track, DragFX_ID, LT_Track, dst_last, true) -- true = move
           r.PreventUIRefresh(-1)
           EndUndoBlock("MOVE FX TO PAD")
@@ -116,6 +116,11 @@ local function ButtonDrawlist(splitter, name, color, a)
     r.ImGui_DrawList_AddRect(f_draw_list, xs - x_offset, ys - x_offset, xe + x_offset, ye + x_offset, (RDM_DnDFX or CustomColorsDefault.RDM_DnDFX), 2,
         nil, 2)
   end
+  if SELECTED and SELECTED[tostring(a)] then
+    local x_offset = 1
+    r.ImGui_DrawList_AddRect(f_draw_list, xs - x_offset, ys - x_offset, xe + x_offset, ye + x_offset, 0x9400d3ff, 2,
+      nil, 1)
+  end
 
   local font_size = r.ImGui_GetFontSize(ctx)
   local char_size_w,char_size_h = r.ImGui_CalcTextSize(ctx, "A")
@@ -128,6 +133,14 @@ local function ButtonDrawlist(splitter, name, color, a)
   if FX[FxGUID].OPEN_PAD == a then
     if not Pad[a] then return end
     Highlight_Itm(WDL, (RDM_Pad_Highlight or CustomColorsDefault.RDM_Pad_Highlight), 0x256BB1ff)
+  end
+  if Pad[a] and Pad[a].Filter_ID then
+    local rv = r.TrackFX_GetParam(track, Pad[a].Filter_ID, 1)
+    if rv == 1 then   
+      local L, T = r.ImGui_GetItemRectMin(ctx)
+      local R, B = r.ImGui_GetItemRectMax(ctx)
+      r.ImGui_DrawList_AddRectFilled(f_draw_list, L, T, R, B + 15, 0xfde58372, rounding)
+    end
   end
 end
 
@@ -163,8 +176,9 @@ local function OpenFXInsidePad(a)
   if not Pad[a] then return end 
   CountPadFX(Pad[a].Pad_Num) -- padfx_idx
   for f = 1, padfx_idx do
-    FX_Id = get_fx_id_from_container_path(track, parent_id, Pad[a].Pad_Num, f)
-    FX_Id_next = get_fx_id_from_container_path(track, parent_id, Pad[a].Pad_Num, f + 1)
+    local _, pad_id = r.TrackFX_GetNamedConfigParm(track, parent_id, "container_item." .. Pad[a].Pad_Num - 1) -- 0 based
+    local FX_Id = ConvertPathToNestedPath(pad_id, f)
+    local FX_Id_next = ConvertPathToNestedPath(pad_id, f + 1)
     local GUID = r.TrackFX_GetFXGUID(LT_Track, FX_Id)
     Spc = AddSpaceBtwnFXs(FX_Id)
     r.ImGui_SameLine(ctx, nil, 0)
@@ -184,10 +198,13 @@ local function DrawPads(loopmin, loopmax)
   local RETURN 
   r.ImGui_DrawListSplitter_Split(SPLITTER, 2)
   CheckDNDType()
+  DoubleClickActions(loopmin, loopmax)
 
   for a = loopmin, loopmax do
+    local midi_octave_offset = r.SNM_GetIntConfigVar("midioctoffs", 0)
+    midi_oct_offs = (midi_octave_offset - 1) * 12
     notenum = a - 1
-    note_name = getNoteName(notenum)
+    note_name = getNoteName(notenum + midi_oct_offs)
 
     if Pad[a] then
       if Pad[a].Rename then
@@ -216,9 +233,8 @@ local function DrawPads(loopmin, loopmax)
       ClickPadActions(a)
     elseif r.ImGui_IsItemClicked(ctx, 1) and Pad[a] and not CTRL then
       FX[FxGUID].OPEN_PAD = toggle2(FX[FxGUID].OPEN_PAD, a)
-    -- elseif r.ImGui_IsItemActive(ctx) and Pad[a] and Mods == Shift then
-    --   local value_raw = { r.ImGui_GetMouseDragDelta(ctx, 0, 0, r.ImGui_MouseButton_Left(), 0.0) }
-    --   r.ShowConsoleMsg(table.unpack(value_raw))
+    elseif SHIFT and r.ImGui_IsMouseDragging(ctx, 0) and r.ImGui_IsItemActive(ctx) then
+      AdjustPadVolume(a)
     else
       DndMoveFX_SRC(a)
     end
@@ -230,25 +246,69 @@ local function DrawPads(loopmin, loopmax)
 
     r.ImGui_SetCursorPos(ctx, x + 25, y + 30)
     if r.ImGui_InvisibleButton(ctx, "S##solo" .. a, 25, 15) then
-      if Pad[a] then
-        CountPads() -- pads_idx
-        if Pad[a].Pad_Num == 1 then
-          retval1 = false
-        else
-          retval1 = r.TrackFX_GetEnabled(track, Pad[a].Previous_Pad_ID)
+      if SELECTED then
+        Unmuted = 0
+        CountSelected = 0
+        for k, v in pairs(SELECTED) do
+          local k = tonumber(k)
+          if Pad[k] then
+          CountSelected = CountSelected + 1
+            if r.TrackFX_GetEnabled(track, Pad[k].Pad_ID) then
+              Unmuted = Unmuted + 1
+            end
+          end
         end
-        local retval2 = r.TrackFX_GetEnabled(track, Pad[a].Next_Pad_ID)
-        if retval1 == false and retval2 == false then -- unsolo
-          for i = 1, pads_idx do
-            local pad_id = get_fx_id_from_container_path(track, parent_id, i)
+        if CountSelected == Unmuted then
+          AllUnmuted = true
+        end
+        CountPads() -- pads_idx
+        HowManyMuted = 0
+        for i = 1, pads_idx do
+          local _, pad_id = r.TrackFX_GetNamedConfigParm(track, parent_id, "container_item." .. i - 1)
+          local rv = r.TrackFX_GetEnabled(track, pad_id)
+          if not rv then
+            HowManyMuted = HowManyMuted + 1
+          end
+        end
+        if AllUnmuted and pads_idx - HowManyMuted == CountSelected then
+          for i = 1, pads_idx do -- unmute all
+            local _, pad_id = r.TrackFX_GetNamedConfigParm(track, parent_id, "container_item." .. i - 1) -- 0 based
             r.TrackFX_SetEnabled(track, pad_id, true)
           end
-        else -- solo
-          for i = 1, pads_idx do
-            local pad_id = get_fx_id_from_container_path(track, parent_id, i)
+        else
+          for i = 1, pads_idx do -- mute all
+            local _, pad_id = r.TrackFX_GetNamedConfigParm(track, parent_id, "container_item." .. i - 1) -- 0 based
             r.TrackFX_SetEnabled(track, pad_id, false)
           end
-          r.TrackFX_SetEnabled(track, Pad[a].Pad_ID, true)
+          for k, v in pairs(SELECTED) do
+            local k = tonumber(k)
+            if Pad[k] then
+              r.TrackFX_SetEnabled(track, Pad[k].Pad_ID, true)
+            end
+          end
+        end
+        SELECTED = nil
+      else
+        if Pad[a] then
+          CountPads() -- pads_idx
+          if Pad[a].Pad_Num == 1 then
+            retval1 = false
+          else
+            retval1 = r.TrackFX_GetEnabled(track, Pad[a].Previous_Pad_ID)
+          end
+          local retval2 = r.TrackFX_GetEnabled(track, Pad[a].Next_Pad_ID)
+          if retval1 == false and retval2 == false then -- unsolo
+            for i = 1, pads_idx do
+              local _, pad_id = r.TrackFX_GetNamedConfigParm(track, parent_id, "container_item." .. i - 1) -- 0 based
+              r.TrackFX_SetEnabled(track, pad_id, true)
+            end
+          else -- solo
+            for i = 1, pads_idx do
+              local _, pad_id = r.TrackFX_GetNamedConfigParm(track, parent_id, "container_item." .. i - 1) -- 0 based
+              r.TrackFX_SetEnabled(track, pad_id, false)
+            end
+            r.TrackFX_SetEnabled(track, Pad[a].Pad_ID, true)
+          end
         end
       end
     end
@@ -261,12 +321,27 @@ local function DrawPads(loopmin, loopmax)
 
     r.ImGui_SetCursorPos(ctx, x + 50, y + 30)
     if r.ImGui_InvisibleButton(ctx, "M##mute" .. a, 25, 15) then
-      if Pad[a] then
+      if SELECTED then
+        for k, v in pairs(SELECTED) do
+          local k = tonumber(k)
+          if Pad[k] and Pad[k].RS5k_ID then 
+            local retval = r.TrackFX_GetEnabled(track, Pad[k].Pad_ID)
+            if retval == true then
+              r.TrackFX_SetEnabled(track, Pad[k].Pad_ID, false)
+            else
+              r.TrackFX_SetEnabled(track, Pad[k].Pad_ID, true)
+            end
+          end
+        end
+        SELECTED = nil
+      else
+        if Pad[a] then
         local retval = r.TrackFX_GetEnabled(track, Pad[a].Pad_ID)
-        if retval == true then
-          r.TrackFX_SetEnabled(track, Pad[a].Pad_ID, false)
-        else
-          r.TrackFX_SetEnabled(track, Pad[a].Pad_ID, true)
+          if retval == true then
+            r.TrackFX_SetEnabled(track, Pad[a].Pad_ID, false)
+          else
+            r.TrackFX_SetEnabled(track, Pad[a].Pad_ID, true)
+          end
         end
       end
     end

--- a/BryanChi_FX_Devices/src/Functions/Filesystem_utils.lua
+++ b/BryanChi_FX_Devices/src/Functions/Filesystem_utils.lua
@@ -1,6 +1,46 @@
 -- @noindex
 r = reaper
 
+function serializeTable(val, name, skipnewlines, depth)
+  skipnewlines = skipnewlines or false
+  depth = depth or 0
+  local tmp = string.rep(" ", depth)
+  if name then
+    if type(name) == "number" and math.floor(name) == name then
+      name = "[" .. name .. "]"
+    elseif not string.match(name, '^[a-zA-z_][a-zA-Z0-9_]*$') then
+      name = string.gsub(name, "'", "\\'")
+      name = "['" .. name .. "']"
+    end
+    tmp = tmp .. name .. " = "
+  end
+  if type(val) == "table" then
+    tmp = tmp .. "{"
+    for k, v in pairs(val) do
+      tmp = tmp .. serializeTable(v, k, skipnewlines, depth + 1) .. ","
+    end
+    tmp = tmp .. string.rep(" ", depth) .. "}"
+  elseif type(val) == "number" then
+    tmp = tmp .. tostring(val)
+  elseif type(val) == "string" then
+    tmp = tmp .. string.format("%q", val)
+  elseif type(val) == "boolean" then
+    tmp = tmp .. (val and "true" or "false")
+  else
+    tmp = tmp .. "\"[inserializeable datatype:" .. type(val) .. "]\""
+  end
+  return tmp
+end
+
+function tableToString(table)
+  return serializeTable(table)
+end
+
+function stringToTable(str)
+  local f, err = load("return " .. str)
+  return f ~= nil and f() or nil
+end
+
 ---@param old_path string
 ---@param new_path string
 ---@return boolean

--- a/BryanChi_FX_Devices/src/Functions/Layout Editor functions.lua
+++ b/BryanChi_FX_Devices/src/Functions/Layout Editor functions.lua
@@ -4,10 +4,10 @@ r = reaper
 local function GetPayload()
     local retval, dndtype, payload = r.ImGui_GetDragDropPayload(ctx)
     if retval then
-      return dndtype, payload
+        return dndtype, payload
     end
-  end
-  
+end
+
 function CheckDnDType()
     local dnd_type = GetPayload()
     DND_ADD_FX = dnd_type == "DND ADD FX"
@@ -19,19 +19,19 @@ end
 local min, max = math.min, math.max
 function IncreaseDecreaseBrightness(color, amt, no_alpha)
     function AdjustBrightness(channel, delta)
-      return min(255, max(0, channel + delta))
+        return min(255, max(0, channel + delta))
     end
-  
+
     local alpha = color & 0xFF
     local blue = (color >> 8) & 0xFF
     local green = (color >> 16) & 0xFF
     local red = (color >> 24) & 0xFF
-  
+
     red = AdjustBrightness(red, amt)
     green = AdjustBrightness(green, amt)
     blue = AdjustBrightness(blue, amt)
     alpha = no_alpha and alpha or AdjustBrightness(alpha, amt)
-  
+
     return (alpha) | (blue << 8) | (green << 16) | (red << 24)
 end
 
@@ -40,9 +40,10 @@ function CalculateColor(color)
     local blue = (color >> 8) & 0xFF
     local green = (color >> 16) & 0xFF
     local red = (color >> 24) & 0xFF
-  
+
     local luminance = (0.299 * red + 0.587 * green + 0.114 * blue) / 255
-    return luminance > 0.5 and (PLink_Edge_LightBG or CustomColorsDefault.PLink_Edge_LightBG) or (PLink_Edge_DarkBG or CustomColorsDefault.PLink_Edge_DarkBG)
+    return luminance > 0.5 and (PLink_Edge_LightBG or CustomColorsDefault.PLink_Edge_LightBG) or
+        (PLink_Edge_DarkBG or CustomColorsDefault.PLink_Edge_DarkBG)
 end
 
 function ButtonDraw(splitter, color, center, radius_outer) -- for drawing to clarify which destination (target) DND goes to
@@ -54,22 +55,24 @@ function ButtonDraw(splitter, color, center, radius_outer) -- for drawing to cla
     local xe, ye = r.ImGui_GetItemRectMax(ctx)
 
     local edge_color = CalculateColor(color)
-  
-    if FX_PLINK and r.ImGui_IsMouseHoveringRect(ctx,xs,ys,xe,ye) then
+
+    if FX_PLINK and r.ImGui_IsMouseHoveringRect(ctx, xs, ys, xe, ye) then
         if KNOB then
-            r.ImGui_DrawList_AddCircle(f_draw_list, center[1], center[2], radius_outer, r.ImGui_GetColorEx(ctx, edge_color), 16, 5)
+            r.ImGui_DrawList_AddCircle(f_draw_list, center[1], center[2], radius_outer,
+                r.ImGui_GetColorEx(ctx, edge_color), 16, 5)
         else
             local x_offset = 2
-            r.ImGui_DrawList_AddRect(f_draw_list, xs - x_offset, ys - x_offset, xe + x_offset, ye + x_offset, r.ImGui_GetColorEx(ctx, edge_color), 2, nil, 5)
+            r.ImGui_DrawList_AddRect(f_draw_list, xs - x_offset, ys - x_offset, xe + x_offset, ye + x_offset,
+                r.ImGui_GetColorEx(ctx, edge_color), 2, nil, 5)
         end
     end
 end
 
 local function WhichClick() -- to alternate left and right click flags for InvisibleButton
     if r.ImGui_IsMouseClicked(ctx, 0) then
-        ClickButton =  r.ImGui_ButtonFlags_MouseButtonLeft()
+        ClickButton = r.ImGui_ButtonFlags_MouseButtonLeft()
     elseif r.ImGui_IsMouseClicked(ctx, 1) then
-        ClickButton =  r.ImGui_ButtonFlags_MouseButtonRight()
+        ClickButton = r.ImGui_ButtonFlags_MouseButtonRight()
     end
     return ClickButton
 end
@@ -81,21 +84,25 @@ local function DnD_PLink_SOURCE(FX_Idx, P_Num)
         local draw_list = r.ImGui_GetForegroundDrawList(ctx)
         local mouse_pos = { r.ImGui_GetMousePos(ctx) }
         local click_pos = { r.ImGui_GetMouseClickedPos(ctx, 1) }
-        r.ImGui_DrawList_AddLine(draw_list, click_pos[1], click_pos[2], mouse_pos[1], mouse_pos[2], PLink or CustomColorsDefault.PLink, 4.0)  -- Draw a line between the button and the mouse cursor                                             
-        lead_fxid = FX_Idx -- storing the original fx id
-        fxidx = FX_Idx -- to prevent an error in layout editor function by not changing FX_Idx itself
-        lead_paramnumber = P_Num      
-        local ret, _ = r.TrackFX_GetNamedConfigParm(LT_Track, lead_fxid, "parent_container") 
-        local rev = ret                       
+        r.ImGui_DrawList_AddLine(draw_list, click_pos[1], click_pos[2], mouse_pos[1], mouse_pos[2],
+            PLink or CustomColorsDefault.PLink, 4.0) -- Draw a line between the button and the mouse cursor
+        lead_fxid =
+            FX_Idx                                   -- storing the original fx id
+        fxidx =
+            FX_Idx                                   -- to prevent an error in layout editor function by not changing FX_Idx itself
+        lead_paramnumber = P_Num
+        local ret, _ = r.TrackFX_GetNamedConfigParm(LT_Track, lead_fxid, "parent_container")
+        local rev = ret
         while rev do -- to get root parent container id
-        root_container = fxidx
-        rev, fxidx = r.TrackFX_GetNamedConfigParm(LT_Track, fxidx, "parent_container")
-        end     
-        if ret then       -- new fx and parameter                   
-            local rv, buf = r.TrackFX_GetNamedConfigParm(LT_Track, root_container, "container_map.add." .. lead_fxid .. "." .. lead_paramnumber)
+            root_container = fxidx
+            rev, fxidx = r.TrackFX_GetNamedConfigParm(LT_Track, fxidx, "parent_container")
+        end
+        if ret then -- new fx and parameter
+            local rv, buf = r.TrackFX_GetNamedConfigParm(LT_Track, root_container,
+                "container_map.add." .. lead_fxid .. "." .. lead_paramnumber)
             lead_fxid = root_container
             lead_paramnumber = buf
-        end 
+        end
         local data = lead_fxid .. "," .. lead_paramnumber
         r.ImGui_SetDragDropPayload(ctx, 'FX PLINK', data)
         local _, param_name = r.TrackFX_GetParamName(LT_Track, lead_fxid, lead_paramnumber)
@@ -115,66 +122,107 @@ local function DnD_PLink_TARGET(FxGUID, Fx_P, FX_Idx, P_Num)
         local rv, payload = r.ImGui_AcceptDragDropPayload(ctx, 'FX PLINK')
         local lead_fxid, lead_paramnumber = payload:match("(.+),(.+)")
         if rv then
-            local rv, bf = r.TrackFX_GetNamedConfigParm(LT_Track, FX_Idx, "param.".. P_Num..".plink.midi_bus")
-            if bf == "15" then -- reset FX Devices' modulation bus/chan                                  
-                r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_bus", 0) -- reset bus and channel because it does not update automatically although in parameter linking midi_* is not available
-                r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_chan", 1) 
-                r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.effect", -1) 
-                r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.active", 0)
+            local rv, bf = r.TrackFX_GetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_bus")
+            if bf == "15" then                                                                            -- reset FX Devices' modulation bus/chan
+                r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_bus", 0) -- reset bus and channel because it does not update automatically although in parameter linking midi_* is not available
+                r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_chan", 1)
+                r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.effect", -1)
+                r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.active", 0)
                 if FX[FxGUID][Fx_P].ModAMT then
                     for Mc = 1, 8, 1 do
                         if FX[FxGUID][Fx_P].ModAMT[Mc] then
                             FX[FxGUID][Fx_P].ModAMT[Mc] = 0
                         end
                     end
-                end                                                    
-            end
-            if lead_fxid ~= nil then   
-                follow_fxid = FX_Idx -- storing the original fx id
-                fxidx = FX_Idx -- to prevent an error in layout editor function by not changing FX_Idx itself
-                follow_paramnumber = P_Num      
-                ret, _ = r.TrackFX_GetNamedConfigParm(LT_Track, follow_fxid, "parent_container")
-                local rev = ret                            
-                while rev do -- to get root parent container id
-                root_container = fxidx
-                rev, fxidx = r.TrackFX_GetNamedConfigParm(LT_Track, fxidx, "parent_container")
                 end
-                if ret then  -- fx inside container                        
-                    local retval, buf = r.TrackFX_GetNamedConfigParm(LT_Track, root_container, "container_map.get." .. follow_fxid .. "." .. follow_paramnumber)                  
+            end
+            if lead_fxid ~= nil then
+                follow_fxid = FX_Idx -- storing the original fx id
+                fxidx = FX_Idx       -- to prevent an error in layout editor function by not changing FX_Idx itself
+                follow_paramnumber = P_Num
+                ret, _ = r.TrackFX_GetNamedConfigParm(LT_Track, follow_fxid, "parent_container")
+                local rev = ret
+                while rev do -- to get root parent container id
+                    root_container = fxidx
+                    rev, fxidx = r.TrackFX_GetNamedConfigParm(LT_Track, fxidx, "parent_container")
+                end
+                if ret then -- fx inside container
+                    local retval, buf = r.TrackFX_GetNamedConfigParm(LT_Track, root_container,
+                        "container_map.get." .. follow_fxid .. "." .. follow_paramnumber)
                     if retval then -- toggle off and remove map
-                        r.TrackFX_SetNamedConfigParm(LT_Track, root_container, "param."..buf..".plink.active", 0)
-                        r.TrackFX_SetNamedConfigParm(LT_Track, root_container, "param."..buf..".plink.effect", -1) 
-                        r.TrackFX_SetNamedConfigParm(LT_Track, root_container, "param."..buf..".plink.param", -1) 
+                        r.TrackFX_SetNamedConfigParm(LT_Track, root_container, "param." .. buf .. ".plink.active", 0)
+                        r.TrackFX_SetNamedConfigParm(LT_Track, root_container, "param." .. buf .. ".plink.effect", -1)
+                        r.TrackFX_SetNamedConfigParm(LT_Track, root_container, "param." .. buf .. ".plink.param", -1)
                         local rv, container_id = r.TrackFX_GetNamedConfigParm(LT_Track, follow_fxid, "parent_container")
                         while rv do -- removing map
-                        _, buf = r.TrackFX_GetNamedConfigParm(LT_Track, container_id, "container_map.get." .. follow_fxid .. "." .. follow_paramnumber)
-                        r.TrackFX_GetNamedConfigParm(LT_Track, container_id, "param." .. buf .. ".container_map.delete")
-                        rv, container_id = r.TrackFX_GetNamedConfigParm(LT_Track, container_id, "parent_container")
+                            _, buf = r.TrackFX_GetNamedConfigParm(LT_Track, container_id,
+                                "container_map.get." .. follow_fxid .. "." .. follow_paramnumber)
+                            r.TrackFX_GetNamedConfigParm(LT_Track, container_id,
+                                "param." .. buf .. ".container_map.delete")
+                            rv, container_id = r.TrackFX_GetNamedConfigParm(LT_Track, container_id, "parent_container")
                         end
-                    else  -- new fx and parameter             
-                        local rv, buf = r.TrackFX_GetNamedConfigParm(LT_Track, root_container, "container_map.add." .. follow_fxid .. "." .. follow_paramnumber) -- map to the root
-                        r.TrackFX_SetNamedConfigParm(LT_Track, root_container, "param."..buf..".plink.active", 1)
-                        r.TrackFX_SetNamedConfigParm(LT_Track, root_container, "param."..buf..".plink.effect", lead_fxid) -- Link (root container + new mapped container parameter) to lead FX
-                        r.TrackFX_SetNamedConfigParm(LT_Track, root_container, "param."..buf..".plink.param", lead_paramnumber) 
+                    else                                                                      -- new fx and parameter
+                        local rv, buf = r.TrackFX_GetNamedConfigParm(LT_Track, root_container,
+                            "container_map.add." .. follow_fxid .. "." .. follow_paramnumber) -- map to the root
+                        r.TrackFX_SetNamedConfigParm(LT_Track, root_container, "param." .. buf .. ".plink.active", 1)
+                        r.TrackFX_SetNamedConfigParm(LT_Track, root_container, "param." .. buf .. ".plink.effect",
+                            lead_fxid) -- Link (root container + new mapped container parameter) to lead FX
+                        r.TrackFX_SetNamedConfigParm(LT_Track, root_container, "param." .. buf .. ".plink.param",
+                            lead_paramnumber)
                     end
-                else -- not inside container
-                    local retval, buf = r.TrackFX_GetNamedConfigParm(LT_Track, follow_fxid, "param."..follow_paramnumber..".plink.active") -- Active(true, 1), Deactivated(true, 0), UnsetYet(false)
-                    if retval and buf == "1" then -- toggle off
+                else                                                       -- not inside container
+                    local retval, buf = r.TrackFX_GetNamedConfigParm(LT_Track, follow_fxid,
+                        "param." .. follow_paramnumber .. ".plink.active") -- Active(true, 1), Deactivated(true, 0), UnsetYet(false)
+                    if retval and buf == "1" then                          -- toggle off
                         value = 0
                         lead_fxid = -1
                         lead_paramnumber = -1
                     else
                         value = 1
                     end
-                    r.TrackFX_SetNamedConfigParm(LT_Track, follow_fxid, "param."..follow_paramnumber..".plink.active", value)
-                    r.TrackFX_SetNamedConfigParm(LT_Track, follow_fxid, "param."..follow_paramnumber..".plink.effect", lead_fxid) 
-                    r.TrackFX_SetNamedConfigParm(LT_Track, follow_fxid, "param."..follow_paramnumber..".plink.param", lead_paramnumber) 
+                    r.TrackFX_SetNamedConfigParm(LT_Track, follow_fxid, "param." .. follow_paramnumber .. ".plink.active",
+                        value)
+                    r.TrackFX_SetNamedConfigParm(LT_Track, follow_fxid, "param." .. follow_paramnumber .. ".plink.effect",
+                        lead_fxid)
+                    r.TrackFX_SetNamedConfigParm(LT_Track, follow_fxid, "param." .. follow_paramnumber .. ".plink.param",
+                        lead_paramnumber)
                 end
-            end  
+            end
         end
         r.ImGui_EndDragDropTarget(ctx)
     end
     r.ImGui_PopStyleColor(ctx)
+end
+
+local function GetSetParamValues(track, fxidx, parm, drag_delta, step)
+    local p_value = r.TrackFX_GetParamNormalized(track, fxidx, parm)
+    local p_value = p_value + (drag_delta * step)
+    if p_value < 0 then p_value = 0 end
+    if p_value > 1 then p_value = 1 end
+    r.TrackFX_SetParamNormalized(track, fxidx, parm, p_value)
+end
+
+local function AdjustParamValue(LT_Track, FX_Idx, P_Num, stepscale)
+    local step = (1 - 0) / (200.0 * stepscale)
+    GetSetParamValues(LT_Track, FX_Idx, P_Num, (4 * Wheel_V), step)
+end
+
+local function AdjustParamWheel(LT_Track, FX_Idx, P_Num)
+    if Ctrl_Scroll then
+        if r.ImGui_IsItemHovered(ctx) and Mods == 0 and not r.ImGui_IsItemActive(ctx) then -- mousewheel to change values
+            AdjustParamValue(LT_Track, FX_Idx, P_Num, 1)
+            --ParameterTooltip(FX_Idx, P_Num)
+        elseif r.ImGui_IsItemHovered(ctx) and Mods == Shift and not r.ImGui_IsItemActive(ctx) then -- mousewheel to change values slightly
+            AdjustParamValue(LT_Track, FX_Idx, P_Num, 6)
+        end
+    else
+        if r.ImGui_IsItemHovered(ctx) and Mods == Ctrl and not r.ImGui_IsItemActive(ctx) then -- mousewheel to change values
+            AdjustParamValue(LT_Track, FX_Idx, P_Num, 1)
+            --ParameterTooltip(FX_Idx, P_Num)
+        elseif r.ImGui_IsItemHovered(ctx) and Mods == Ctrl + Shift and not r.ImGui_IsItemActive(ctx) then -- mousewheel to change values slightly
+            AdjustParamValue(LT_Track, FX_Idx, P_Num, 6)
+        end
+    end
 end
 
 ---@param ctx ImGui_Context
@@ -199,12 +247,12 @@ end
 function AddKnob(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P_Num, Style, Radius,
                  item_inner_spacing, Disabled, LblTextSize, Lbl_Pos, V_Pos, ImgPath)
     if Style == 'Pro C' then r.gmem_attach('ParamValues') end
-    local FxGUID =  r.TrackFX_GetFXGUID(LT_Track, FX_Idx)
+    local FxGUID = r.TrackFX_GetFXGUID(LT_Track, FX_Idx)
     if not FxGUID then return end
     FX[FxGUID] = FX[FxGUID] or {}
     FX[FxGUID][Fx_P] = FX[FxGUID][Fx_P] or {}
 
-    if FX[FxGUID].Morph_Value_Edit or Mods == Alt + Ctrl then r.ImGui_BeginDisabled(ctx) end    
+    if FX[FxGUID].Morph_Value_Edit or Mods == Alt + Ctrl then r.ImGui_BeginDisabled(ctx) end
     local p_value = p_value or 0
     local radius_outer = Radius or Df.KnobRadius;
     local FP = FX[FxGUID][Fx_P]
@@ -248,40 +296,46 @@ function AddKnob(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P
     local ANGLE_MIN = 3.141592 * 0.75
     local ANGLE_MAX = 3.141592 * 2.25
     local BtnOffset
-    
+
     if Lbl_Pos == 'Top' then BtnOffset = -line_height end
 
     WhichClick()
     r.ImGui_InvisibleButton(ctx, label, radius_outer * 2,
         radius_outer * 2 + line_height + item_inner_spacing[2] + (BtnOffset or 0), ClickButton) -- ClickButton to alternate left/right dragging
-        if ClickButton == r.ImGui_ButtonFlags_MouseButtonLeft() then -- left drag to adjust parameters
-            if r.ImGui_BeginDragDropSource(ctx, r.ImGui_DragDropFlags_SourceNoPreviewTooltip()) then
-                r.ImGui_SetDragDropPayload(ctx, 'my_type', 'my_data')
-                Knob_Active  = true
-                Clr_SldrGrab = getClr(r.ImGui_Col_Text())
+    if ClickButton == r.ImGui_ButtonFlags_MouseButtonLeft() then                                -- left drag to adjust parameters
+        if r.ImGui_BeginDragDropSource(ctx, r.ImGui_DragDropFlags_SourceNoPreviewTooltip()) then
+            r.ImGui_SetDragDropPayload(ctx, 'my_type', 'my_data')
+            Knob_Active  = true
+            Clr_SldrGrab = getClr(r.ImGui_Col_Text())
 
-                HideCursorTillMouseUp(0)
-                r.ImGui_SetMouseCursor(ctx, r.ImGui_MouseCursor_None())
-                if -mouse_delta[2] ~= 0.0 then
-                    local stepscale = 1
-                    if Mods == Shift then stepscale = 3 end
-                    local step = (v_max - v_min) / (200.0 * stepscale)
-                    p_value = p_value + (-mouse_delta[2] * step)
-                    if p_value < v_min then p_value = v_min end
-                    if p_value > v_max then p_value = v_max end
-                    value_changed = true
-                    r.TrackFX_SetParamNormalized(LT_Track, FX_Idx, P_Num, p_value)
-                    MvingP_Idx = F_Tp
-                    Tweaking = P_Num .. FxGUID
-                end
-                r.ImGui_EndDragDropSource(ctx)
+            HideCursorTillMouseUp(0)
+            r.ImGui_SetMouseCursor(ctx, r.ImGui_MouseCursor_None())
+            if -mouse_delta[2] ~= 0.0 then
+                local stepscale = 1
+                if Mods == Shift then stepscale = 3 end
+                local step = (v_max - v_min) / (200.0 * stepscale)
+                p_value = p_value + (-mouse_delta[2] * step)
+                if p_value < v_min then p_value = v_min end
+                if p_value > v_max then p_value = v_max end
+                value_changed = true
+                r.TrackFX_SetParamNormalized(LT_Track, FX_Idx, P_Num, p_value)
+                MvingP_Idx = F_Tp
+                Tweaking = P_Num .. FxGUID
             end
-        elseif ClickButton ==  r.ImGui_ButtonFlags_MouseButtonRight() and not AssigningMacro then -- right drag to link parameters
-            DnD_PLink_SOURCE(FX_Idx, P_Num)
+            r.ImGui_EndDragDropSource(ctx)
         end
-        KNOB = true
-        DnD_PLink_TARGET(FxGUID, Fx_P, FX_Idx, P_Num)
-        ButtonDraw(SPLITTER, FX[FxGUID].BgClr or CustomColorsDefault.FX_Devices_Bg, center, radius_outer)
+    elseif ClickButton == r.ImGui_ButtonFlags_MouseButtonRight() and not AssigningMacro then -- right drag to link parameters
+        DnD_PLink_SOURCE(FX_Idx, P_Num)
+    end
+    KNOB = true
+    DnD_PLink_TARGET(FxGUID, Fx_P, FX_Idx, P_Num)
+    ButtonDraw(SPLITTER, FX[FxGUID].BgClr or CustomColorsDefault.FX_Devices_Bg, center, radius_outer)
+    local focused_window, hwnd = GetFocusedWindow()
+    if focused_window == "FX Devices" then
+        r.JS_Window_SetFocus(hwnd)
+        AdjustParamWheel(LT_Track, FX_Idx, P_Num)
+    end
+
     if V_Pos == 'Free' then
         local Ox, Oy = r.ImGui_GetCursorScreenPos(ctx)
         r.ImGui_DrawList_AddTextEx(draw_list, _G[V_Font], FX[FxGUID][Fx_P].V_FontSize or Knob_DefaultFontSize,
@@ -536,7 +590,8 @@ function AddKnob(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P
             if r.ImGui_IsItemClicked(ctx) or r.ImGui_IsItemClicked(ctx, 1) then
                 if IsLBtnClicked or IsRBtnClicked then
                     FP.TweakingAB_Val = P_Num
-                    retval, Orig_Baseline = r.TrackFX_GetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".mod.baseline") 
+                    retval, Orig_Baseline = r.TrackFX_GetNamedConfigParm(LT_Track, FX_Idx,
+                        "param." .. P_Num .. ".mod.baseline")
                 end
                 if not FP.TweakingAB_Val then
                     local offsetA, offsetB
@@ -555,29 +610,33 @@ function AddKnob(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P
                     if FX[FxGUID].Morph_ID then -- if Morph Sldr is linked to a CC
                         local A = (MsY - BtnT) / sizeY
                         local Scale = FX[FxGUID].MorphB[P_Num] - A
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.active", 1)   -- 1 active, 0 inactive
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.scale", Scale)   -- Scale
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.effect", -100) -- -100 enables midi_msg*
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.param", -1)   -- -1 not parameter link
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_bus", 15) -- 0 based, 15 = Bus 16
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_chan", 16) -- 0 based, 0 = Omni
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_msg", 160)   -- 160 is Aftertouch
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_msg2", FX[FxGUID].Morph_ID) -- CC value
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".mod.baseline", A) -- Baseline
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.active", 1)     -- 1 active, 0 inactive
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.scale", Scale)  -- Scale
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.effect", -100)  -- -100 enables midi_msg*
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.param", -1)     -- -1 not parameter link
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_bus", 15)  -- 0 based, 15 = Bus 16
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_chan", 16) -- 0 based, 0 = Omni
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_msg", 160) -- 160 is Aftertouch
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_msg2",
+                            FX[FxGUID].Morph_ID)                                                                    -- CC value
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".mod.baseline", A)     -- Baseline
                     end
                 elseif IsRBtnHeld then
                     local drag = FX[FxGUID].MorphB[P_Num] + select(2, r.ImGui_GetMouseDelta(ctx, 1)) * -0.01
                     FX[FxGUID].MorphB[P_Num] = SetMinMax(drag, 0, 1)
-                    if FX[FxGUID].Morph_ID then -- if Morph Sldr is linked to a CC
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.active", 1)   -- 1 active, 0 inactive
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.scale", FX[FxGUID].MorphB[P_Num] - FX[FxGUID].MorphA[P_Num])   -- Scale
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.effect", -100) -- -100 enables midi_msg*
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.param", -1)   -- -1 not parameter link
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_bus", 15) -- 0 based, 15 = Bus 16
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_chan", 16) -- 0 based, 0 = Omni
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_msg", 160)   -- 160 is Aftertouch
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_msg2", FX[FxGUID].Morph_ID) -- CC value
-                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".mod.baseline", Orig_Baseline) -- Baseline
+                    if FX[FxGUID].Morph_ID then                                                                     -- if Morph Sldr is linked to a CC
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.active", 1)     -- 1 active, 0 inactive
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.scale",
+                            FX[FxGUID].MorphB[P_Num] - FX[FxGUID].MorphA[P_Num])                                    -- Scale
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.effect", -100)  -- -100 enables midi_msg*
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.param", -1)     -- -1 not parameter link
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_bus", 15)  -- 0 based, 15 = Bus 16
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_chan", 16) -- 0 based, 0 = Omni
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_msg", 160) -- 160 is Aftertouch
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_msg2",
+                            FX[FxGUID].Morph_ID)                                                                    -- CC value
+                        r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".mod.baseline",
+                            Orig_Baseline)                                                                          -- Baseline
                     end
                 end
                 if IsLBtnHeld then
@@ -682,7 +741,7 @@ function AddKnob(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P
         if not FP.WhichCC then
             r.TrackFX_SetParamNormalized(LT_Track, FX_Idx, P_Num, p_value)
         else
-            local unsetcc = r.TrackFX_SetNamedConfigParm(LT_Track, LT_FXNum, "param."..P_Num..".plink.active", 0)   -- 1 active, 0 inactive
+            local unsetcc = r.TrackFX_SetNamedConfigParm(LT_Track, LT_FXNum, "param." .. P_Num .. ".plink.active", 0) -- 1 active, 0 inactive
             r.TrackFX_SetParamNormalized(LT_Track, FX_Idx, P_Num, FX[FxGUID][Fx_P].V)
         end
     end
@@ -734,11 +793,10 @@ function AddKnob(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P
     if FP.ModAMT then -- Draw modlines  circular
         local offset = 0
         local BipOfs = 0
-        FP.ModBipolar= FP.ModBipolar or {}
+        FP.ModBipolar = FP.ModBipolar or {}
 
-        
+
         for Macro, v in ipairs(MacroNums) do
-            
             if FP.ModAMT[Macro] then
                 --if Modulation has been assigned to params
                 local P_V_Norm = r.TrackFX_GetParamNormalized(LT_Track, FX_Idx, P_Num)
@@ -746,28 +804,27 @@ function AddKnob(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P
                 --- indicator of where the param is currently
                 local PosAftrMod = ANGLE_MIN + (ANGLE_MAX - ANGLE_MIN) * (P_V_Norm)
 
-                    if FP.ModBipolar[Macro] then 
-                        BipOfs =  - FP.ModAMT[Macro]
-                    end
+                if FP.ModBipolar[Macro] then
+                    BipOfs = -FP.ModAMT[Macro]
+                end
 
-                r.ImGui_DrawList_PathArcTo(draw_list, center[1], center[2], radius_outer * 0.75, angle, PosAftrMod )
+                r.ImGui_DrawList_PathArcTo(draw_list, center[1], center[2], radius_outer * 0.75, angle, PosAftrMod)
 
                 r.ImGui_DrawList_PathStroke(draw_list, EightColors.Bright[Macro], nil, radius_outer / 2)
                 r.ImGui_DrawList_PathClear(draw_list)
 
                 --- shows modulation range
-                local Range = SetMinMax(angle + (ANGLE_MAX - ANGLE_MIN) * FP.ModAMT[Macro],ANGLE_MIN, ANGLE_MAX)
-                local angle = angle 
-                if BipOfs ~=0 then 
-
-                    local Range = SetMinMax(angle + (ANGLE_MAX - ANGLE_MIN) * -(  FP.ModAMT[Macro]   ) ,ANGLE_MIN, ANGLE_MAX) 
-                    r.ImGui_DrawList_PathArcTo(draw_list, center[1], center[2], radius_outer - 1 + offset, angle,Range )
+                local Range = SetMinMax(angle + (ANGLE_MAX - ANGLE_MIN) * FP.ModAMT[Macro], ANGLE_MIN, ANGLE_MAX)
+                local angle = angle
+                if BipOfs ~= 0 then
+                    local Range = SetMinMax(angle + (ANGLE_MAX - ANGLE_MIN) * -(FP.ModAMT[Macro]), ANGLE_MIN, ANGLE_MAX)
+                    r.ImGui_DrawList_PathArcTo(draw_list, center[1], center[2], radius_outer - 1 + offset, angle, Range)
                     r.ImGui_DrawList_PathStroke(draw_list, EightColors.HighSat_MidBright[Macro], nil,
-                    radius_outer * 0.1)
+                        radius_outer * 0.1)
                     r.ImGui_DrawList_PathClear(draw_list)
-                end 
-                r.ImGui_DrawList_PathArcTo(draw_list, center[1], center[2], radius_outer - 1 + offset, angle, Range )
-           
+                end
+                r.ImGui_DrawList_PathArcTo(draw_list, center[1], center[2], radius_outer - 1 + offset, angle, Range)
+
                 r.ImGui_DrawList_PathStroke(draw_list, EightColors.HighSat_MidBright[Macro], nil,
                     radius_outer * 0.1)
                 r.ImGui_DrawList_PathClear(draw_list)
@@ -789,19 +846,21 @@ function AddKnob(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P
         if FP.ModAMT[M] + p_value > 1 then FP.ModAMT[M] = 1 - p_value end
         if FP.ModAMT[M] + p_value < 0 then FP.ModAMT[M] = -p_value end
 
-        local BipolarOut 
-        if Mods == Alt then 
-            FP.ModAMT[M] = math.abs( FP.ModAMT[M])
-            BipolarOut = FP.ModAMT[M]  + 100
+        local BipolarOut
+        if Mods == Alt then
+            FP.ModAMT[M] = math.abs(FP.ModAMT[M])
+            BipolarOut = FP.ModAMT[M] + 100
 
-            FP.ModBipolar[M] = true 
-            r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: FX' .. FxGUID .. 'Prm' .. Fx_P .. 'Macro' .. M .. 'Mod Bipolar','True', true)
-        else 
+            FP.ModBipolar[M] = true
+            r.GetSetMediaTrackInfo_String(LT_Track,
+                'P_EXT: FX' .. FxGUID .. 'Prm' .. Fx_P .. 'Macro' .. M .. 'Mod Bipolar', 'True', true)
+        else
             FP.ModBipolar[M] = nil
-            r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: FX' .. FxGUID .. 'Prm' .. Fx_P .. 'Macro' .. M .. 'Mod Bipolar','', true)
+            r.GetSetMediaTrackInfo_String(LT_Track,
+                'P_EXT: FX' .. FxGUID .. 'Prm' .. Fx_P .. 'Macro' .. M .. 'Mod Bipolar', '', true)
         end
 
-       
+
         r.gmem_write(4, 1) --tells jsfx that user is changing Mod Amount
         r.gmem_write(1000 * AssigningMacro + Trk.Prm.Assign, BipolarOut or FP.ModAMT[M])
         r.ImGui_ResetMouseDragDelta(ctx, 1)
@@ -866,9 +925,9 @@ function AddSlider(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx,
     local Font = 'Font_Andale_Mono_' .. roundUp(FP.FontSize or LblTextSize or Knob_DefaultFontSize, 1)
 
     local V_Font = 'Arial_' .. roundUp(FP.V_FontSize or LblTextSize or Knob_DefaultFontSize, 1)
-    r.ImGui_PushStyleVar(ctx, r.ImGui_StyleVar_FramePadding(), 0, FP.Height or 3 )
+    r.ImGui_PushStyleVar(ctx, r.ImGui_StyleVar_FramePadding(), 0, FP.Height or 3)
 
-    
+
 
 
     if FP.Lbl_Pos == 'Left' then
@@ -938,9 +997,9 @@ function AddSlider(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx,
                 if Get then MyText(Param_Value, _G[V_Font], FP.V_Clr or r.ImGui_GetColor(ctx, r.ImGui_Col_Text())) end
             end
         end
-        
 
-        FP.V = FP.V or r.TrackFX_GetParamNormalized(LT_Track,FX_Idx,P_Num)
+
+        FP.V = FP.V or r.TrackFX_GetParamNormalized(LT_Track, FX_Idx, P_Num)
         if DraggingMorph == FxGUID then p_value = r.TrackFX_GetParamNormalized(LT_Track, FX_Idx, P_Num) end
 
 
@@ -957,7 +1016,7 @@ function AddSlider(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx,
         r.ImGui_PopStyleColor(ctx, ClrPop)
 
         RemoveModulationIfDoubleRClick(FxGUID, Fx_P, P_Num, FX_Idx)
-        
+
         local SldrR, SldrB = r.ImGui_GetItemRectMax(ctx)
         local SldrL, SldrT = r.ImGui_GetItemRectMin(ctx)
 
@@ -966,12 +1025,12 @@ function AddSlider(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx,
         local is_active = r.ImGui_IsItemActive(ctx)
         local is_hovered = r.ImGui_IsItemHovered(ctx)
 
-        
+
         local button_x, button_y = r.ImGui_GetCursorPos(ctx)
         r.ImGui_SetCursorPosY(ctx, button_y - (PosB - PosT))
         WhichClick()
         r.ImGui_InvisibleButton(ctx, '##plink' .. P_Num, PosR - PosL, PosB - PosT, ClickButton) -- for parameter link
-        if ClickButton ==  r.ImGui_ButtonFlags_MouseButtonRight() and not AssigningMacro then -- right drag to link parameters
+        if ClickButton == r.ImGui_ButtonFlags_MouseButtonRight() and not AssigningMacro then    -- right drag to link parameters
             DnD_PLink_SOURCE(FX_Idx, P_Num)
         end
 
@@ -997,7 +1056,7 @@ function AddSlider(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx,
         if Disable == 'Disabled' then
             r.ImGui_DrawList_AddRectFilled(draw_list, PosL, PosT, PosL + SldrGrbPos, PosB, 0x000000cc, Rounding)
         end
-        
+
         if is_active then
             p_value = SetMinMax(p_value, v_min, v_max)
             value_changed = true
@@ -1052,7 +1111,7 @@ function AddSlider(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx,
             if Trk.Prm.WhichMcros[CC .. TrkID] == nil then
                 r.TrackFX_SetParamNormalized(LT_Track, FX_Idx, P_Num, p_value)
             elseif Trk.Prm.WhichMcros[CC .. TrkID] ~= nil then
-                local unsetcc = r.TrackFX_SetNamedConfigParm(LT_Track, LT_FXNum, "param."..P_Num..".plink.active", 0)   -- 1 active, 0 inactive
+                local unsetcc = r.TrackFX_SetNamedConfigParm(LT_Track, LT_FXNum, "param." .. P_Num .. ".plink.active", 0) -- 1 active, 0 inactive
                 r.TrackFX_SetParamNormalized(LT_Track, FX_Idx, P_Num, FX[FxGUID][Fx_P].V)
             end
         end
@@ -1112,7 +1171,8 @@ function AddSlider(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx,
                 if r.ImGui_IsMouseHoveringRect(ctx, PosL, PosT, PosR, PosB) and not MorphingMenuOpen then
                     if IsLBtnClicked or IsRBtnClicked then
                         FP.TweakingAB_Val = P_Num
-                        retval, Orig_Baseline = r.TrackFX_GetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".mod.baseline") 
+                        retval, Orig_Baseline = r.TrackFX_GetNamedConfigParm(LT_Track, FX_Idx,
+                            "param." .. P_Num .. ".mod.baseline")
                     end
                     if not FP.TweakingAB_Val then
                         local offsetA, offsetB
@@ -1135,28 +1195,32 @@ function AddSlider(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx,
                         if FX[FxGUID].Morph_ID then -- if Morph Sldr is linked to a CC
                             local A = (MsX - PosL) / sizeX
                             local Scale = FX[FxGUID].MorphB[P_Num] - A
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.active", 1)   -- 1 active, 0 inactive
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.scale", Scale)   -- Scale
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.effect", -100) -- -100 enables midi_msg*
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.param", -1)   -- -1 not parameter link
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_bus", 15) -- 0 based, 15 = Bus 16
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_chan", 16) -- 0 based, 0 = Omni
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_msg", 160)   -- 160 is Aftertouch
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_msg2", FX[FxGUID].Morph_ID) -- CC value
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".mod.baseline", A) -- Baseline  
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.active", 1)     -- 1 active, 0 inactive
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.scale", Scale)  -- Scale
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.effect", -100)  -- -100 enables midi_msg*
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.param", -1)     -- -1 not parameter link
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_bus", 15)  -- 0 based, 15 = Bus 16
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_chan", 16) -- 0 based, 0 = Omni
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_msg", 160) -- 160 is Aftertouch
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_msg2",
+                                FX[FxGUID].Morph_ID)                                                                    -- CC value
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".mod.baseline", A)     -- Baseline
                         end
                     elseif IsRBtnHeld then
                         FX[FxGUID].MorphB[P_Num] = SetMinMax((MsX - PosL) / sizeX, 0, 1)
-                        if FX[FxGUID].Morph_ID then -- if Morph Sldr is linked to a CC
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.active", 1)   -- 1 active, 0 inactive
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.scale", FX[FxGUID].MorphB[P_Num] - FX[FxGUID].MorphA[P_Num])   -- Scale
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.effect", -100) -- -100 enables midi_msg*
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.param", -1)   -- -1 not parameter link
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_bus", 15) -- 0 based, 15 = Bus 16
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_chan", 16) -- 0 based, 0 = Omni
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_msg", 160)   -- 160 is Aftertouch
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_msg2", FX[FxGUID].Morph_ID) -- CC value
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".mod.baseline", Orig_Baseline) -- Baseline 
+                        if FX[FxGUID].Morph_ID then                                                                     -- if Morph Sldr is linked to a CC
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.active", 1)     -- 1 active, 0 inactive
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.scale",
+                                FX[FxGUID].MorphB[P_Num] - FX[FxGUID].MorphA[P_Num])                                    -- Scale
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.effect", -100)  -- -100 enables midi_msg*
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.param", -1)     -- -1 not parameter link
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_bus", 15)  -- 0 based, 15 = Bus 16
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_chan", 16) -- 0 based, 0 = Omni
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_msg", 160) -- 160 is Aftertouch
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_msg2",
+                                FX[FxGUID].Morph_ID)                                                                    -- CC value
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".mod.baseline",
+                                Orig_Baseline)                                                                          -- Baseline
                         end
                     end
                     if IsLBtnHeld then
@@ -1295,7 +1359,6 @@ end
 ---@param Lbl_Pos? Position
 function AddCombo(ctx, LT_Track, FX_Idx, Label, WhichPrm, Options, Width, Style, FxGUID, Fx_P, OptionValues,
                   LabelOveride, CustomLbl, Lbl_Pos)
-
     LabelValue = Label .. 'Value'
     local FP
     FX[FxGUID or ''][Fx_P or ''] = FX[FxGUID or ''][Fx_P or ''] or {}
@@ -1303,7 +1366,7 @@ function AddCombo(ctx, LT_Track, FX_Idx, Label, WhichPrm, Options, Width, Style,
     if Fx_P then FP = FX[FxGUID][Fx_P] end
     local V_Font = 'Font_Andale_Mono_' .. roundUp(FP.V_FontSize or LblTextSize or Knob_DefaultFontSize, 1)
     local Font = 'Font_Andale_Mono_' .. roundUp(FP.FontSize or LblTextSize or Knob_DefaultFontSize, 1)
-    
+
     if Fx_P and FP then
         if (FP.Lbl_Pos == 'Left' and Lbl_Pos ~= 'No Lbl') or FP.Lbl_Pos == 'Top' then
             local name
@@ -1318,8 +1381,7 @@ function AddCombo(ctx, LT_Track, FX_Idx, Label, WhichPrm, Options, Width, Style,
                 SL()
             end
         end
-        r.ImGui_PushStyleVar(ctx, r.ImGui_StyleVar_FramePadding(), 0, FP.Height or 3 )
-
+        r.ImGui_PushStyleVar(ctx, r.ImGui_StyleVar_FramePadding(), 0, FP.Height or 3)
     end
 
     if LabelOveride then _G[LabelValue] = LabelOveride end
@@ -1499,7 +1561,7 @@ function AddCombo(ctx, LT_Track, FX_Idx, Label, WhichPrm, Options, Width, Style,
     r.ImGui_PopStyleVar(ctx)
     r.ImGui_EndGroup(ctx)
     r.ImGui_PopStyleColor(ctx, PopClr or 0)
-   if rv then return rv, v_format end
+    if rv then return rv, v_format end
 end
 
 ---@param LT_Track MediaTrack
@@ -1514,12 +1576,11 @@ end
 ---@param FxGUID string
 ---@return integer
 function AddSwitch(LT_Track, FX_Idx, Value, P_Num, BgClr, Lbl_Type, Fx_P, F_Tp, FontSize, FxGUID)
-
     local clr, TextW, Font
     FX[FxGUID][Fx_P] = FX[FxGUID][Fx_P] or {}
     local FP = FX[FxGUID][Fx_P]
     local V_Font = 'Font_Andale_Mono_' .. roundUp(FP.V_FontSize or LblTextSize or Knob_DefaultFontSize, 1)
-    r.ImGui_PushStyleVar(ctx, r.ImGui_StyleVar_FramePadding(), 0, FP.Height or 3 )
+    r.ImGui_PushStyleVar(ctx, r.ImGui_StyleVar_FramePadding(), 0, FP.Height or 3)
 
     if FontSize then
         Font = 'Font_Andale_Mono_' .. roundUp(FontSize, 1); r.ImGui_PushFont(ctx, _G[Font])
@@ -1697,12 +1758,12 @@ end
 function AddDrag(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P_Num, Style, Sldr_Width,
                  item_inner_spacing, Disable, Lbl_Clickable, Lbl_Pos, V_Pos, DragDir, AllowInput)
     local FxGUID = FxGUID or r.TrackFX_GetFXGUID(LT_Track, FX_Idx)
-    if FxGUID then 
+    if FxGUID then
         FX[FxGUID][Fx_P] = FX[FxGUID][Fx_P] or {}
 
         --local FxGUID = FXGUID[FX_Idx]
         local FP = FX[FxGUID][Fx_P]
-        r.ImGui_PushStyleVar(ctx, r.ImGui_StyleVar_FramePadding(), 0, FP.Height or 3 )
+        r.ImGui_PushStyleVar(ctx, r.ImGui_StyleVar_FramePadding(), 0, FP.Height or 3)
 
 
         if FX[FxGUID].Morph_Value_Edit or (Mods == Alt + Ctrl and is_hovered) then r.ImGui_BeginDisabled(ctx) end
@@ -1777,7 +1838,7 @@ function AddDrag(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P
         local value_changed = false
         local is_active = r.ImGui_IsItemActive(ctx)
         local is_hovered = r.ImGui_IsItemHovered(ctx)
-        
+
         if is_active == true then Knob_Active = true end
         if Knob_Active == true then
             if IsLBtnHeld == false then Knob_Active = false end
@@ -1806,7 +1867,8 @@ function AddDrag(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P
                 if r.ImGui_IsMouseHoveringRect(ctx, PosL, PosT, PosR, PosB) and not MorphingMenuOpen then
                     if IsLBtnClicked or IsRBtnClicked then
                         FP.TweakingAB_Val = P_Num
-                        retval, Orig_Baseline = r.TrackFX_GetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".mod.baseline") 
+                        retval, Orig_Baseline = r.TrackFX_GetNamedConfigParm(LT_Track, FX_Idx,
+                            "param." .. P_Num .. ".mod.baseline")
                     end
                     if not FP.TweakingAB_Val then
                         local offsetA, offsetB
@@ -1827,28 +1889,32 @@ function AddDrag(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P
                         if FX[FxGUID].Morph_ID then -- if Morph Sldr is linked to a CC
                             local A = (MsX - PosL) / sizeX
                             local Scale = FX[FxGUID].MorphB[P_Num] - A
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.active", 1)   -- 1 active, 0 inactive
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.scale", Scale)   -- Scale
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.effect", -100) -- -100 enables midi_msg*
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.param", -1)   -- -1 not parameter link
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_bus", 15) -- 0 based, 15 = Bus 16
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_chan", 16) -- 0 based, 0 = Omni
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_msg", 160)   -- 160 is Aftertouch
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_msg2", FX[FxGUID].Morph_ID) -- CC value
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".mod.baseline", A) -- Baseline  
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.active", 1)     -- 1 active, 0 inactive
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.scale", Scale)  -- Scale
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.effect", -100)  -- -100 enables midi_msg*
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.param", -1)     -- -1 not parameter link
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_bus", 15)  -- 0 based, 15 = Bus 16
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_chan", 16) -- 0 based, 0 = Omni
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_msg", 160) -- 160 is Aftertouch
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_msg2",
+                                FX[FxGUID].Morph_ID)                                                                    -- CC value
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".mod.baseline", A)     -- Baseline
                         end
                     elseif IsRBtnHeld then
                         FX[FxGUID].MorphB[P_Num] = SetMinMax((MsX - PosL) / sizeX, 0, 1)
-                        if FX[FxGUID].Morph_ID then -- if Morph Sldr is linked to a CC
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.active", 1)   -- 1 active, 0 inactive
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.scale", FX[FxGUID].MorphB[P_Num] - FX[FxGUID].MorphA[P_Num])   -- Scale
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.effect", -100) -- -100 enables midi_msg*
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.param", -1)   -- -1 not parameter link
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_bus", 15) -- 0 based, 15 = Bus 16
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_chan", 16) -- 0 based, 0 = Omni
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_msg", 160)   -- 160 is Aftertouch
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".plink.midi_msg2", FX[FxGUID].Morph_ID) -- CC value
-                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param."..P_Num..".mod.baseline", Orig_Baseline) -- Baseline 
+                        if FX[FxGUID].Morph_ID then                                                                     -- if Morph Sldr is linked to a CC
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.active", 1)     -- 1 active, 0 inactive
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.scale",
+                                FX[FxGUID].MorphB[P_Num] - FX[FxGUID].MorphA[P_Num])                                    -- Scale
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.effect", -100)  -- -100 enables midi_msg*
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.param", -1)     -- -1 not parameter link
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_bus", 15)  -- 0 based, 15 = Bus 16
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_chan", 16) -- 0 based, 0 = Omni
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_msg", 160) -- 160 is Aftertouch
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".plink.midi_msg2",
+                                FX[FxGUID].Morph_ID)                                                                    -- CC value
+                            r.TrackFX_SetNamedConfigParm(LT_Track, FX_Idx, "param." .. P_Num .. ".mod.baseline",
+                                Orig_Baseline)                                                                          -- Baseline
                         end
                     end
                     if IsLBtnHeld then
@@ -1948,7 +2014,7 @@ function AddDrag(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P
         r.ImGui_SetCursorPosY(ctx, button_y - (PosB - PosT))
         WhichClick()
         r.ImGui_InvisibleButton(ctx, '##plink' .. P_Num, PosR - PosL, PosB - PosT, ClickButton) -- for parameter link
-        if ClickButton ==  r.ImGui_ButtonFlags_MouseButtonRight() and not AssigningMacro then -- right drag to link parameters
+        if ClickButton == r.ImGui_ButtonFlags_MouseButtonRight() and not AssigningMacro then    -- right drag to link parameters
             DnD_PLink_SOURCE(FX_Idx, P_Num)
         end
 
@@ -1988,7 +2054,7 @@ function AddDrag(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P
             if not FP.WhichCC then
                 r.TrackFX_SetParamNormalized(LT_Track, FX_Idx, P_Num, p_value)
             else
-                local unsetcc = r.TrackFX_SetNamedConfigParm(LT_Track, LT_FXNum, "param."..P_Num..".plink.active", 0)   -- 1 active, 0 inactive
+                local unsetcc = r.TrackFX_SetNamedConfigParm(LT_Track, LT_FXNum, "param." .. P_Num .. ".plink.active", 0) -- 1 active, 0 inactive
                 r.TrackFX_SetParamNormalized(LT_Track, FX_Idx, P_Num, FX[FxGUID][Fx_P].V)
             end
         end
@@ -2205,12 +2271,10 @@ end
 
 ---@param Sel_Track_FX_Count integer
 function RetrieveFXsSavedLayout(Sel_Track_FX_Count)
-
     if LT_Track then
         TREE = BuildFXTree(LT_Track or tr)
 
         for FX_Idx = 0, Sel_Track_FX_Count - 1, 1 do
-            
             local PrmInst, Line, FX_Name
             local FxGUID = r.TrackFX_GetFXGUID(LT_Track, FX_Idx)
             --local file = CallFile('r', FX_Name..'.ini', 'FX Layouts')
@@ -2222,8 +2286,7 @@ function RetrieveFXsSavedLayout(Sel_Track_FX_Count)
                     local _, FX_Name = r.TrackFX_GetFXName(LT_Track, FX_Idx)
                     local FX_Name = ChangeFX_Name(FX_Name)
 
-                    if LO[FX_Name] then 
-
+                    if LO[FX_Name] then
                         FX[FxGUID] = FX[FxGUID] or {}
                         local T = LO[FX_Name]
                         FX[FxGUID].MorphHide = T.MorphHide
@@ -2235,51 +2298,51 @@ function RetrieveFXsSavedLayout(Sel_Track_FX_Count)
                         FX[FxGUID].TitleClr = T.TitleClr
                         FX[FxGUID].CustomTitle = T.CustomTitle
 
-                        for i, v in ipairs(T) do 
-                            FX[FxGUID][i] = FX[FxGUID][i] or {}
-                            local FP = FX[FxGUID][i]
-                            FP.Name         =  v.Name       
-                            FP.Num          =  v.Num        
-                            FP.Sldr_W       =  v.Sldr_W     
-                            FP.Type         =  v.Type       
-                            FP.PosX         =  v.PosX       
-                            FP.PosY         =  v.PosY       
-                            FP.Style        =  v.Style      
-                            FP.V_FontSize   =  v.V_FontSize 
-                            FP.CustomLbl    =  v.CustomLbl  
-                            FP.FontSize     =  v.FontSize
-                            FP.Height       =  v.Height
-                            FP.BgClr        =  v.BgClr
-                            FP.GrbClr       =  v.GrbClr
-                            FP.Lbl_Pos      =  v.Lbl_Pos
-                            FP.V_Pos        =  v.V_Pos 
-                            FP.Lbl_Clr      =  v.Lbl_Clr
-                            FP.V_Clr        =  v.V_Clr
-                            FP.DragDir      =  v.DragDir
-                            FP.Value_Thick  =  v.Value_Thick
-                            FP.V_Pos_X      =  v.V_Pos_X
-                            FP.V_Pos_Y      =  v.V_Pos_Y
-                            FP.Lbl_Pos_X    =  v.Lbl_Pos_X
-                            FP.Lbl_Pos_Y    =  v.Lbl_Pos_Y 
-                            FP.Image        =  v.Image
-                            FP.ImagePath    =  v.ImagePath
-                            FP.ConditionPrm =  v.ConditionPrm
-                            FP.ConditionPrm_V = v.ConditionPrm_V
+                        for i, v in ipairs(T) do
+                            FX[FxGUID][i]          = FX[FxGUID][i] or {}
+                            local FP               = FX[FxGUID][i]
+                            FP.Name                = v.Name
+                            FP.Num                 = v.Num
+                            FP.Sldr_W              = v.Sldr_W
+                            FP.Type                = v.Type
+                            FP.PosX                = v.PosX
+                            FP.PosY                = v.PosY
+                            FP.Style               = v.Style
+                            FP.V_FontSize          = v.V_FontSize
+                            FP.CustomLbl           = v.CustomLbl
+                            FP.FontSize            = v.FontSize
+                            FP.Height              = v.Height
+                            FP.BgClr               = v.BgClr
+                            FP.GrbClr              = v.GrbClr
+                            FP.Lbl_Pos             = v.Lbl_Pos
+                            FP.V_Pos               = v.V_Pos
+                            FP.Lbl_Clr             = v.Lbl_Clr
+                            FP.V_Clr               = v.V_Clr
+                            FP.DragDir             = v.DragDir
+                            FP.Value_Thick         = v.Value_Thick
+                            FP.V_Pos_X             = v.V_Pos_X
+                            FP.V_Pos_Y             = v.V_Pos_Y
+                            FP.Lbl_Pos_X           = v.Lbl_Pos_X
+                            FP.Lbl_Pos_Y           = v.Lbl_Pos_Y
+                            FP.Image               = v.Image
+                            FP.ImagePath           = v.ImagePath
+                            FP.ConditionPrm        = v.ConditionPrm
+                            FP.ConditionPrm_V      = v.ConditionPrm_V
                             FP.ConditionPrm_V_Norm = v.ConditionPrm_V_Norm
-                            FP.Switch_On_Clr = v.Switch_On_Clr
+                            FP.Switch_On_Clr       = v.Switch_On_Clr
                             for i = 2, 5, 1 do
-                                FP['ConditionPrm'..i]  = v['ConditionPrm'..i]
-                                FP['ConditionPrm_V'..i]  = v['ConditionPrm_V'..i]
-                                FP['ConditionPrm_V_Norm'..i]  = v['ConditionPrm_V_Norm'..i]
+                                FP['ConditionPrm' .. i]        = v['ConditionPrm' .. i]
+                                FP['ConditionPrm_V' .. i]      = v['ConditionPrm_V' .. i]
+                                FP['ConditionPrm_V_Norm' .. i] = v['ConditionPrm_V_Norm' .. i]
                             end
                             FP.ManualValues = v.ManualValues
                             FP.ManualValuesFormat = v.ManualValuesFormat
                             FP.Draw = v.Draw
                         end
-                        FX[FxGUID].Draw =  T.Draw
-                        
+                        FX[FxGUID].Draw = T.Draw
                     else
-                        local dir_path = ConcatPath(r.GetResourcePath(), 'Scripts', 'FX Devices', 'BryanChi_FX_Devices', 'src', 'FX Layouts')
+                        local dir_path = ConcatPath(r.GetResourcePath(), 'Scripts', 'FX Devices', 'BryanChi_FX_Devices',
+                            'src', 'FX Layouts')
                         local file_path = ConcatPath(dir_path, FX_Name .. '.ini')
 
                         -- Create directory for file if it doesn't exist
@@ -2290,15 +2353,15 @@ function RetrieveFXsSavedLayout(Sel_Track_FX_Count)
                         LO[FX_Name] = LO[FX_Name] or {}
                         local T = LO[FX_Name]
                         if file then
-
                             Line = get_lines(file_path)
                             FX[FxGUID].FileLine = Line
                             Content = file:read('*a')
                             local Ct = Content
 
-                            
 
-                            T.MorphHide = r.GetSetMediaTrackInfo_String(LT_Track,'P_EXT: FX Morph Hide' .. FxGUID, 'true', true)
+
+                            T.MorphHide = r.GetSetMediaTrackInfo_String(LT_Track, 'P_EXT: FX Morph Hide' .. FxGUID,
+                                'true', true)
                             T.Round = RecallGlobInfo(Ct, 'Edge Rounding = ', 'Num')
                             T.GrbRound = RecallGlobInfo(Ct, 'Grb Rounding = ', 'Num')
                             T.BgClr = RecallGlobInfo(Ct, 'BgClr = ', 'Num')
@@ -2339,39 +2402,39 @@ function RetrieveFXsSavedLayout(Sel_Track_FX_Count)
                                     local function L(n)
                                         return Line[n + (40 - 14) * (Fx_P - 1)]
                                     end
-                                    FX[FxGUID]       = FX[FxGUID] or {}
-                                    T[Fx_P] = T[Fx_P] or {}
+                                    FX[FxGUID]    = FX[FxGUID] or {}
+                                    T[Fx_P]       = T[Fx_P] or {}
 
-                                    local FP         = T[Fx_P]
-                                    local ID         = FxGUID .. Fx_P
+                                    local FP      = T[Fx_P]
+                                    local ID      = FxGUID .. Fx_P
 
-                                    FP.Name          = RecallInfo(Ct, 'Name', Fx_P)
-                                    FP.Num           = RecallInfo(Ct, 'Num', Fx_P, 'Num')
-                                    FP.Sldr_W        = RecallInfo(Ct, 'Width', Fx_P, 'Num')
-                                    FP.Type          = RecallInfo(Ct, 'Type', Fx_P)
-                                    FP.PosX          = RecallInfo(Ct, 'Pos X', Fx_P, 'Num')
-                                    FP.PosY          = RecallInfo(Ct, 'Pos Y', Fx_P, 'Num')
-                                    FP.Style         = RecallInfo(Ct, 'Style', Fx_P)
-                                    FP.V_FontSize    = RecallInfo(Ct, 'Value Font Size', Fx_P, 'Num')
-                                    FP.CustomLbl     = RecallInfo(Ct, 'Custom Label', Fx_P)
+                                    FP.Name       = RecallInfo(Ct, 'Name', Fx_P)
+                                    FP.Num        = RecallInfo(Ct, 'Num', Fx_P, 'Num')
+                                    FP.Sldr_W     = RecallInfo(Ct, 'Width', Fx_P, 'Num')
+                                    FP.Type       = RecallInfo(Ct, 'Type', Fx_P)
+                                    FP.PosX       = RecallInfo(Ct, 'Pos X', Fx_P, 'Num')
+                                    FP.PosY       = RecallInfo(Ct, 'Pos Y', Fx_P, 'Num')
+                                    FP.Style      = RecallInfo(Ct, 'Style', Fx_P)
+                                    FP.V_FontSize = RecallInfo(Ct, 'Value Font Size', Fx_P, 'Num')
+                                    FP.CustomLbl  = RecallInfo(Ct, 'Custom Label', Fx_P)
                                     if FP.CustomLbl == '' then FP.CustomLbl = nil end
-                                    FP.FontSize     = RecallInfo(Ct, 'Font Size', Fx_P, 'Num')
-                                    FP.Height       = RecallInfo(Ct, 'Slider Height', Fx_P, 'Num')
-                                    FP.BgClr        = RecallInfo(Ct, 'BgClr', Fx_P, 'Num')
-                                    FP.GrbClr       = RecallInfo(Ct, 'GrbClr', Fx_P, 'Num')
-                                    FP.Lbl_Pos      = RecallInfo(Ct, 'Label Pos', Fx_P)
-                                    FP.V_Pos        = RecallInfo(Ct, 'Value Pos', Fx_P)
-                                    FP.Lbl_Clr      = RecallInfo(Ct, 'Lbl Clr', Fx_P, 'Num')
-                                    FP.V_Clr        = RecallInfo(Ct, 'V Clr', Fx_P, 'Num')
-                                    FP.DragDir      = RecallInfo(Ct, 'Drag Direction', Fx_P, 'Num')
-                                    FP.Value_Thick  = RecallInfo(Ct, 'Value Thickness', Fx_P, 'Num')
-                                    FP.V_Pos_X      = RecallInfo(Ct, 'Value Free Pos X', Fx_P, 'Num')
-                                    FP.V_Pos_Y      = RecallInfo(Ct, 'Value Free Pos Y', Fx_P, 'Num')
-                                    FP.Lbl_Pos_X    = RecallInfo(Ct, 'Label Free Pos X', Fx_P, 'Num')
-                                    FP.Lbl_Pos_Y    = RecallInfo(Ct, 'Label Free Pos Y', Fx_P, 'Num')
-                                    FP.Switch_On_Clr= RecallInfo(Ct, 'Switch On Clr', Fx_P, 'Num')
+                                    FP.FontSize      = RecallInfo(Ct, 'Font Size', Fx_P, 'Num')
+                                    FP.Height        = RecallInfo(Ct, 'Slider Height', Fx_P, 'Num')
+                                    FP.BgClr         = RecallInfo(Ct, 'BgClr', Fx_P, 'Num')
+                                    FP.GrbClr        = RecallInfo(Ct, 'GrbClr', Fx_P, 'Num')
+                                    FP.Lbl_Pos       = RecallInfo(Ct, 'Label Pos', Fx_P)
+                                    FP.V_Pos         = RecallInfo(Ct, 'Value Pos', Fx_P)
+                                    FP.Lbl_Clr       = RecallInfo(Ct, 'Lbl Clr', Fx_P, 'Num')
+                                    FP.V_Clr         = RecallInfo(Ct, 'V Clr', Fx_P, 'Num')
+                                    FP.DragDir       = RecallInfo(Ct, 'Drag Direction', Fx_P, 'Num')
+                                    FP.Value_Thick   = RecallInfo(Ct, 'Value Thickness', Fx_P, 'Num')
+                                    FP.V_Pos_X       = RecallInfo(Ct, 'Value Free Pos X', Fx_P, 'Num')
+                                    FP.V_Pos_Y       = RecallInfo(Ct, 'Value Free Pos Y', Fx_P, 'Num')
+                                    FP.Lbl_Pos_X     = RecallInfo(Ct, 'Label Free Pos X', Fx_P, 'Num')
+                                    FP.Lbl_Pos_Y     = RecallInfo(Ct, 'Label Free Pos Y', Fx_P, 'Num')
+                                    FP.Switch_On_Clr = RecallInfo(Ct, 'Switch On Clr', Fx_P, 'Num')
 
-                                    local path = RecallInfo(Ct, 'Custom Image', Fx_P)
+                                    local path       = RecallInfo(Ct, 'Custom Image', Fx_P)
 
                                     if path then
                                         FP.ImagePath = path
@@ -2381,7 +2444,7 @@ function RetrieveFXsSavedLayout(Sel_Track_FX_Count)
                                     end
 
 
-                                    FP.ConditionPrm = RecallInfo(Ct, 'Condition Param', '\n'..Fx_P , 'Num', '|')
+                                    FP.ConditionPrm = RecallInfo(Ct, 'Condition Param', '\n' .. Fx_P, 'Num', '|')
                                     for i = 2, 5, 1 do
                                         FP['ConditionPrm' .. i] = RecallInfo(Ct, 'Condition Param' .. i, Fx_P, 'Num', '|')
                                     end
@@ -2394,8 +2457,10 @@ function RetrieveFXsSavedLayout(Sel_Track_FX_Count)
 
 
                                     if FP.ConditionPrm then
-                                        FP.ConditionPrm_V = RecallIntoTable(Ct, Fx_P .. '. Condition Param = %d+|1=', Fx_P, nil)
-                                        FP.ConditionPrm_V_Norm = RecallIntoTable(Ct, Fx_P .. '. Condition Param Norm = |1=', Fx_P,'Num')
+                                        FP.ConditionPrm_V = RecallIntoTable(Ct, Fx_P .. '. Condition Param = %d+|1=',
+                                            Fx_P, nil)
+                                        FP.ConditionPrm_V_Norm = RecallIntoTable(Ct,
+                                            Fx_P .. '. Condition Param Norm = |1=', Fx_P, 'Num')
                                     end
                                     for i = 2, 5, 1 do
                                         FP['ConditionPrm_V' .. i] = RecallIntoTable(Ct, Fx_P ..
@@ -2405,7 +2470,8 @@ function RetrieveFXsSavedLayout(Sel_Track_FX_Count)
                                     end
 
                                     if Prm.InstAdded[FxGUID] ~= true then
-                                        StoreNewParam(FxGUID, FP.Name, FP.Num, FX_Idx, 'Not Deletable', 'AddingFromExtState',
+                                        StoreNewParam(FxGUID, FP.Name, FP.Num, FX_Idx, 'Not Deletable',
+                                            'AddingFromExtState',
                                             Fx_P, FX_Idx, TrkID)
                                         r.SetProjExtState(0, 'FX Devices', 'FX' .. FxGUID .. 'Params Added', 'true')
                                     end
@@ -2466,7 +2532,7 @@ function RetrieveFXsSavedLayout(Sel_Track_FX_Count)
                                             d.Y_Gap_VA = RC('Y_Gap_VA', 'Num')
                                             d.Y_Gap_VA_GR = RC('Y_Gap_VA GR', 'Num')
                                             d.RPT_Clr = RC('RPT_Clr', 'Num')
-                                            
+
 
                                             local path = RC('Image_Path')
                                             if path then
@@ -2527,7 +2593,7 @@ function RetrieveFXsSavedLayout(Sel_Track_FX_Count)
                             if Top then
                                 local Ct = Content
 
-                                
+
                                 local DrawInst = RecallGlobInfo(Ct, 'Total Number of Drawings = ', 'Num')
 
 
@@ -2584,39 +2650,30 @@ function RetrieveFXsSavedLayout(Sel_Track_FX_Count)
 
 
 
-            local rv, FX_Count = r.TrackFX_GetNamedConfigParm( LT_Track, FX_Idx, 'container_count')
-           
-            if rv  then     -- if iterated fx is a container
+            local rv, FX_Count = r.TrackFX_GetNamedConfigParm(LT_Track, FX_Idx, 'container_count')
+
+            if rv then -- if iterated fx is a container
                 local Upcoming_Container
-                if TREE[FX_Idx+1] then 
-                    if TREE[FX_Idx+1].children then 
-
-                        local function get_Container_Info ()
-                            
-                            for i, v in ipairs(Upcoming_Container or TREE[FX_Idx+1].children) do 
-
+                if TREE[FX_Idx + 1] then
+                    if TREE[FX_Idx + 1].children then
+                        local function get_Container_Info()
+                            for i, v in ipairs(Upcoming_Container or TREE[FX_Idx + 1].children) do
                                 local FX_Id = v.addr_fxid
                                 local GUID = v.GUID
                                 GetInfo(GUID, FX_Id)
-                                if v.children then 
+                                if v.children then
                                     Upcoming_Container = v.children
-                                    get_Container_Info ()
-
+                                    get_Container_Info()
                                 end
-                                
-                                
                             end
                         end
 
-                        
-                            get_Container_Info ()
 
-                        
+                        get_Container_Info()
                     end
                 end
-
-            else 
-                GetInfo(FxGUID,FX_Idx)
+            else
+                GetInfo(FxGUID, FX_Idx)
             end
         end
     end
@@ -2741,21 +2798,21 @@ function DrawModLines(Macro, AddIndicator, McroV, FxGUID, F_Tp, Sldr_Width, P_V,
     local SizeX, SizeY = r.ImGui_GetItemRectSize(ctx)
     MacroModLineOffset = 0
 
-    
-    
-    local ModAmt , BipOfs  = FP.ModAMT[Macro] , 0 
-    if FP then 
+
+
+    local ModAmt, BipOfs = FP.ModAMT[Macro], 0
+    if FP then
         FP.ModBipolar = FP.ModBipolar or {}
-        if FP.ModBipolar[Macro] then 
-            ModAmt = FP.ModAMT[Macro] 
-            BipOfs =  - FP.ModAMT[Macro]
+        if FP.ModBipolar[Macro] then
+            ModAmt = FP.ModAMT[Macro]
+            BipOfs = -FP.ModAMT[Macro]
         end
-    end 
+    end
 
     if Vertical ~= 'Vert' then
         PosX_End_Of_Slider = (Sldr_Width) + L
         SldrGrabPos = SizeX * P_V
-        SliderCurPos = L + SldrGrabPos 
+        SliderCurPos = L + SldrGrabPos
         SliderModPos = SliderCurPos + ((ModAmt * Sldr_Width) or 0)
         SliderModPos = SetMinMax(SliderModPos, L, PosX_End_Of_Slider)
     elseif Vertical == 'Vert' then
@@ -2783,18 +2840,21 @@ function DrawModLines(Macro, AddIndicator, McroV, FxGUID, F_Tp, Sldr_Width, P_V,
             r.gmem_attach('ParamValues')
             MOD = math.abs(SetMinMax(r.gmem_read(100 + Macro) / 127, -1, 1))
         end
-        
 
-        if MOD then 
 
-            local ModAmt = ModAmt 
-            if BipOfs~= 0  then  ModAmt = ModAmt*2  end 
-            if Vertical == 'Vert'   then
-                ModPosWithAmt = math.max(SliderCurPos - (MOD * Sldr_Width * ModAmt) - BipOfs*Sldr_Width or 0, PosX_End_Of_Slider)
-                r.ImGui_DrawList_AddRectFilled(drawlist, L, SliderCurPos, R, ModPosWithAmt or SliderCurPos, Midsat,Rounding)
+        if MOD then
+            local ModAmt = ModAmt
+            if BipOfs ~= 0 then ModAmt = ModAmt * 2 end
+            if Vertical == 'Vert' then
+                ModPosWithAmt = math.max(SliderCurPos - (MOD * Sldr_Width * ModAmt) - BipOfs * Sldr_Width or 0,
+                    PosX_End_Of_Slider)
+                r.ImGui_DrawList_AddRectFilled(drawlist, L, SliderCurPos, R, ModPosWithAmt or SliderCurPos, Midsat,
+                    Rounding)
             else
-                ModPosWithAmt = math.min(SliderCurPos + (MOD * Sldr_Width * ModAmt) + BipOfs*Sldr_Width or 0, PosX_End_Of_Slider)
-                r.ImGui_DrawList_AddRectFilled(drawlist, SliderCurPos, T, (ModPosWithAmt or SliderCurPos or 0), B,Midsat, Rounding)
+                ModPosWithAmt = math.min(SliderCurPos + (MOD * Sldr_Width * ModAmt) + BipOfs * Sldr_Width or 0,
+                    PosX_End_Of_Slider)
+                r.ImGui_DrawList_AddRectFilled(drawlist, SliderCurPos, T, (ModPosWithAmt or SliderCurPos or 0), B, Midsat,
+                    Rounding)
             end
         end
     end
@@ -2802,10 +2862,10 @@ function DrawModLines(Macro, AddIndicator, McroV, FxGUID, F_Tp, Sldr_Width, P_V,
     --- mod range indicator line
     if Vertical == 'Vert' then
         local SliderCurPos = SliderCurPos - BipOfs * Sldr_Width
-        r.ImGui_DrawList_AddRectFilled(drawlist, L - offset, SliderCurPos, L - offset, SliderModPos, MidBright,Rounding)
+        r.ImGui_DrawList_AddRectFilled(drawlist, L - offset, SliderCurPos, L - offset, SliderModPos, MidBright, Rounding)
     else
         local SliderCurPos = SliderCurPos + BipOfs * Sldr_Width
-        r.ImGui_DrawList_AddLine(drawlist, SliderCurPos, T - offset, SliderModPos or 1, T - offset,MidBright, 2)
+        r.ImGui_DrawList_AddLine(drawlist, SliderCurPos, T - offset, SliderModPos or 1, T - offset, MidBright, 2)
     end
 end
 
@@ -2906,7 +2966,7 @@ function SaveLayoutEditings(FX_Name, FX_Idx, FxGUID)
             write('Label Free Pos X', FP.Lbl_Pos_X)
             write('Label Free Pos Y', FP.Lbl_Pos_Y)
             write('Custom Image', FP.ImagePath)
-            
+
 
 
 
@@ -3367,7 +3427,7 @@ end
 ---@return number w
 ---@return number h
 function Calc_strip_uv(img, V)
-    local V = V or 0 
+    local V = V or 0
     local w, h = r.ImGui_Image_GetSize(img)
     local FrameNum = h / w
 

--- a/BryanChi_FX_Devices/src/Functions/Layout Editor functions.lua
+++ b/BryanChi_FX_Devices/src/Functions/Layout Editor functions.lua
@@ -1012,6 +1012,11 @@ function AddSlider(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx,
         KNOB = false
         DnD_PLink_TARGET(FxGUID, Fx_P, FX_Idx, P_Num)
         ButtonDraw(SPLITTER, FX[FxGUID].BgClr or CustomColorsDefault.FX_Devices_Bg, nil, nil)
+        local focused_window, hwnd = GetFocusedWindow()
+        if focused_window == "FX Devices" then
+            r.JS_Window_SetFocus(hwnd)
+            AdjustParamWheel(LT_Track, FX_Idx, P_Num)
+        end
         if GrabSize then r.ImGui_PopStyleVar(ctx) end
         r.ImGui_PopStyleColor(ctx, ClrPop)
 
@@ -1830,6 +1835,11 @@ function AddDrag(ctx, label, labeltoShow, p_value, v_min, v_max, Fx_P, FX_Idx, P
         KNOB = false
         DnD_PLink_TARGET(FxGUID, Fx_P, FX_Idx, P_Num)
         ButtonDraw(SPLITTER, FX[FxGUID].BgClr or CustomColorsDefault.FX_Devices_Bg, nil, nil)
+        local focused_window, hwnd = GetFocusedWindow()
+        if focused_window == "FX Devices" then
+            r.JS_Window_SetFocus(hwnd)
+            AdjustParamWheel(LT_Track, FX_Idx, P_Num)
+        end
         if Style == 'FX Layering' then r.ImGui_PopStyleVar(ctx) end
 
         r.ImGui_PopStyleColor(ctx, 3)


### PR DESCRIPTION
Added general settings menu which handle all settings e.g. Pro-C gr, Pro-Q3 analyzer, ctrl scroll and reverse scroll. Maybe we can add a tooltip later. StoreSettings function saves them as extstate "FXDEVICES" "Settings" and stored extstate is converted back  to table with stringToTable function. So you don't need to add a new extstate each time you add a new settings and you can just add it to StoreSettings function.

When focused_window is 'FX Devices' (via GetFocusedWindow function), window will have focus automatically, and Horizontal_Scroll function deals with reverse scroll and scroll value (shift+ scroll to scroll slightly for example). [The second bug](https://forum.cockos.com/showpost.php?p=2774537&postcount=959) is fixed accordingly.

Bringing back modifications below because they are not related to the format change refactoring.
[move attachImagesAndFonts() and TrashIcon() outside of for loop](https://github.com/BryanChi/BryanChi-FX-Devices/commit/c5cf219231886f8241c7c12227355e06452f098a)
https://github.com/BryanChi/BryanChi-FX-Devices/pull/28