### PR TITLE
Fixed DnD to a space before FX crash

### DIFF
--- a/BryanChi_FX_Devices/src/Functions/GUI.lua
+++ b/BryanChi_FX_Devices/src/Functions/GUI.lua
@@ -3611,7 +3611,6 @@ function AddSpaceBtwnFXs(FX_Idx, SpaceIsBeforeRackMixer, AddLastSpace, LyrID, Sp
                     im.SameLine(ctx, nil, 0)
 
                     Dvdr.Width[TblIdxForSpace] = 0
-                    im.EndDragDropTarget(ctx)
                 else
                     HighlightSelectedItem(0xffffff22, nil, 0, L, T, R, B, h, w, 0, 0, 'GetItemRect', Foreground)
 
@@ -3666,6 +3665,7 @@ function AddSpaceBtwnFXs(FX_Idx, SpaceIsBeforeRackMixer, AddLastSpace, LyrID, Sp
                         MoveFX(payload, copypos, false)
                     end
                     im.SameLine(ctx, nil, 0)
+
                 end
             elseif Payload_Type == 'FX Layer Repositioning' then -- FX Layer Repositioning
                 local FXGUID_RackMixer = r.TrackFX_GetFXGUID(LT_Track, DragFX_ID)
@@ -3682,7 +3682,7 @@ function AddSpaceBtwnFXs(FX_Idx, SpaceIsBeforeRackMixer, AddLastSpace, LyrID, Sp
                     DontAllowDrop = true
                     im.SameLine(ctx, nil, 0)
                     Dvdr.Width[TblIdxForSpace] = 0
-                    im.EndDragDropTarget(ctx)
+
 
                     --[[  ]]
                     Dvdr.Width[FX_Idx] = 0
@@ -3754,8 +3754,8 @@ function AddSpaceBtwnFXs(FX_Idx, SpaceIsBeforeRackMixer, AddLastSpace, LyrID, Sp
                 end
                 im.PopStyleColor(ctx)
 
-                im.EndDragDropTarget(ctx)
             end
+            im.EndDragDropTarget(ctx)
         else
             Dvdr.Width[TblIdxForSpace] = 0
             Dvdr.Clr[ClrLbl] = 0x131313ff

--- a/BryanChi_FX_Devices/src/Functions/Layout Editor functions.lua
+++ b/BryanChi_FX_Devices/src/Functions/Layout Editor functions.lua
@@ -84,10 +84,8 @@ local function DnD_PLink_SOURCE(FX_Idx, P_Num)
         local click_pos = { im.GetMouseClickedPos(ctx, 1) }
         im.DrawList_AddLine(draw_list, click_pos[1], click_pos[2], mouse_pos[1], mouse_pos[2],
             PLink or CustomColorsDefault.PLink, 4.0) -- Draw a line between the button and the mouse cursor
-        lead_fxid =
-            FX_Idx                                   -- storing the original fx id
-        fxidx =
-            FX_Idx                                   -- to prevent an error in layout editor function by not changing FX_Idx itself
+        lead_fxid = FX_Idx                                   -- storing the original fx id
+        fxidx = FX_Idx                                   -- to prevent an error in layout editor function by not changing FX_Idx itself
         lead_paramnumber = P_Num
         local ret, _ = r.TrackFX_GetNamedConfigParm(LT_Track, lead_fxid, "parent_container")
         local rev = ret


### PR DESCRIPTION
Fixed  the "g.DragDropWithinTarget = false bug" which occurs when dragging FX or parameter to a space before FX.

BeginDragDropTarget and EndDragDropTarget is a set, and I placed EndDragDropTarget at the end of if statement so that you don't need/forget to place it within nested if statement, which happens this time.